### PR TITLE
Update YouTube link with autoplay and disable related videos

### DIFF
--- a/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
+++ b/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
@@ -4,7 +4,7 @@
 export const AppExternalLinks = {
   readMore:
     'https://drive.google.com/file/d/16KAaOAQudDQ_PvGfebXiB51mtR_M42UW/view?usp=sharing',
-  previewVideoYoutube: 'https://youtu.be/a0Z6DSX3iqE',
+  previewVideoYoutube: 'https://youtu.be/a0Z6DSX3iqE?autoplay=1&rel=0',
   webgl: 'https://altzone.fi/game/',
   downloadAndroid:
     'https://play.google.com/store/apps/details?id=eu.altgame.altzone',

--- a/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
+++ b/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
@@ -4,7 +4,7 @@
 export const AppExternalLinks = {
   readMore:
     'https://drive.google.com/file/d/16KAaOAQudDQ_PvGfebXiB51mtR_M42UW/view?usp=sharing',
-  previewVideoYoutube: 'https://www.youtube.com/embed/a0Z6DSX3iqE?si=eeif6PonxBAT2NgF&rel=0',
+  previewVideoYoutube: 'https://youtu.be/a0Z6DSX3iqE',
   webgl: 'https://altzone.fi/game/',
   downloadAndroid:
     'https://play.google.com/store/apps/details?id=eu.altgame.altzone',
@@ -18,5 +18,3 @@ export const AppExternalLinks = {
     'https://docs.google.com/forms/d/e/1FAIpQLScYGN0JlcgkqKpotNeE6hyWLG7oI1g19myAtrHf2mmHz7g7AA/viewform',
   stub: '#developerChangeThisLink',
 } as const;
-
-

--- a/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
+++ b/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
@@ -4,7 +4,7 @@
 export const AppExternalLinks = {
   readMore:
     'https://drive.google.com/file/d/16KAaOAQudDQ_PvGfebXiB51mtR_M42UW/view?usp=sharing',
-  previewVideoYoutube: 'https://www.youtube.com/embed/a0Z6DSX3iqE?rel=0',
+  previewVideoYoutube: 'https://www.youtube.com/embed/a0Z6DSX3iqE?si=eeif6PonxBAT2NgF&rel=0',
   webgl: 'https://altzone.fi/game/',
   downloadAndroid:
     'https://play.google.com/store/apps/details?id=eu.altgame.altzone',

--- a/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
+++ b/frontend-next-migration/src/shared/appLinks/appExternalLinks.ts
@@ -4,7 +4,7 @@
 export const AppExternalLinks = {
   readMore:
     'https://drive.google.com/file/d/16KAaOAQudDQ_PvGfebXiB51mtR_M42UW/view?usp=sharing',
-  previewVideoYoutube: 'https://youtu.be/a0Z6DSX3iqE?autoplay=1&rel=0',
+  previewVideoYoutube: 'https://www.youtube.com/embed/a0Z6DSX3iqE?rel=0',
   webgl: 'https://altzone.fi/game/',
   downloadAndroid:
     'https://play.google.com/store/apps/details?id=eu.altgame.altzone',
@@ -18,3 +18,5 @@ export const AppExternalLinks = {
     'https://docs.google.com/forms/d/e/1FAIpQLScYGN0JlcgkqKpotNeE6hyWLG7oI1g19myAtrHf2mmHz7g7AA/viewform',
   stub: '#developerChangeThisLink',
 } as const;
+
+

--- a/frontend-next-migration/src/shared/ui/VideoContent/ui/VideoContentYoutube.tsx
+++ b/frontend-next-migration/src/shared/ui/VideoContent/ui/VideoContentYoutube.tsx
@@ -147,14 +147,17 @@ export default class VideoContentYoutube extends Component<VideoContentProps, Vi
 
         return (
                 <div className={this.state.className+ " " + "__iframeVideo"} style={{position: "relative",width:"100%",height:"0",paddingBottom:"56.25%"}}>
-                    <iframe allowFullScreen={true} className={this.state.className+"__iframe"} style={{maxWidth: "100%", width:"100%", position:"absolute", left:"0"}}
-                            key={"vc_"+this.state.videoId+"__iframe"}
-                            title={this.state.title}
-                            loading="lazy"
-                            // alt={this.state.title}
-                            src={this.state.autoPlay
-                        ? "https://www.youtube.com/embed/"+this.state.videoId+"?rel=false&showinfo=false&autoplay=true"
-                                : "https://www.youtube.com/embed/"+this.state.videoId} allow='autoplay; encrypted-media' width="100%"
+                    <iframe
+                        allowFullScreen={true}
+                        className={this.state.className+"__iframe"}
+                        style={{maxWidth: "100%", width:"100%", position:"absolute", left:"0"}}
+                        key={"vc_"+this.state.videoId+"__iframe"}
+                        title={this.state.title}
+                        loading="lazy"
+                        // alt={this.state.title}
+                        src={this.state.autoPlay
+                        ? "https://www.youtube.com/embed/"+this.state.videoId+"?rel=0&showinfo=false&autoplay=true"
+                                : "https://www.youtube.com/embed/"+this.state.videoId+"?rel=0&showinfo=false&autoplay=true"} allow='autoplay; encrypted-media' width="100%"
                             height="100%" frameBorder={0} />
                 </div>
             );


### PR DESCRIPTION
The YouTube link for the preview video now includes parameters to enable autoplay and disable related videos. This change enhances user experience by ensuring the video starts automatically and stays focused on our content.