### PR TITLE
Add hero group label to the hero page

### DIFF
--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
@@ -143,30 +143,6 @@
   max-height: 38%;
 }
 
-.heroGroupLabel{
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  text-align: center;
-  flex-direction: row;
-
-  &Title{
-    background-repeat: no-repeat;
-    background-position: center center;
-    background-attachment: scroll;
-    background-size: cover;
-    padding: 4vw;
-    text-shadow: 1px 1px 2px black;
-
-    & span {
-      font-size: calc(12px + 0.8vw);
-      display: inline-block;
-      transform: translateX(calc(12px + 0.2vw));
-      hyphens: manual;
-    }
-  }
-}
-
 .heroName {
   text-align: center;
   margin-bottom: 2rem;

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
@@ -62,7 +62,7 @@
   z-index: 1;
 }
 
-.container.isMobile, {
+.container.isMobile {
   max-width: 35rem;
   padding: 0 1.2rem;
 }

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.module.scss
@@ -143,6 +143,30 @@
   max-height: 38%;
 }
 
+.heroGroupLabel{
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  flex-direction: row;
+
+  &Title{
+    background-repeat: no-repeat;
+    background-position: center center;
+    background-attachment: scroll;
+    background-size: cover;
+    padding: 4vw;
+    text-shadow: 1px 1px 2px black;
+
+    & span {
+      font-size: calc(12px + 0.8vw);
+      display: inline-block;
+      transform: translateX(calc(12px + 0.2vw));
+      hyphens: manual;
+    }
+  }
+}
+
 .heroName {
   text-align: center;
   margin-bottom: 2rem;

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -65,6 +65,8 @@ const HeroContainer = (props: Props) => {
     [cls.isWidescreen]: isWidescreenSize,
   };
 
+  const heroType = convertHeroGroupToHeroType(group);
+
   return (
       <div className={classNames(cls.componentWrapper, combinedModCss)}>
         <Link
@@ -132,7 +134,7 @@ const HeroContainer = (props: Props) => {
                 <div className={cls.heroDescription}>
                   <h3>{heroDescription}</h3>
                 </div>
-                <HeroGroupLabel heroType={HeroType.FIGHTER} />
+                {heroType && <HeroGroupLabel heroType={heroType} />}
               </div>
             </div>
           </div>

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -56,6 +56,24 @@ function defineHeroGroupLabelText(heroType: HeroType) {
   }
 }
 
+type HeroGroupLabelProps = Readonly<{
+  heroType: HeroType,
+  textBgColor: StaticImageData
+}>;
+function HeroGroupLabel({heroType, textBgColor}: HeroGroupLabelProps) {
+  const labelText = defineHeroGroupLabelText(heroType);
+
+  return(
+    <div className={`${cls.heroGroupLabel}`}>
+      <h3
+          className={cls.heroGroupLabelTitle}
+          style={{backgroundImage: `url(${textBgColor.src})`}}
+      >
+        <span>{labelText}</span>
+      </h3>
+  </div>
+  );
+}
 
 const heroGroups = [
   { group: "TORJUJAT // RETROFLEKTIO", textBgColor: red },
@@ -148,6 +166,7 @@ const heroGroups = [
                 <div className={cls.heroDescription}>
                   <h3>{heroDescription}</h3>
                 </div>
+                <HeroGroupLabel heroType={HeroType.FIGHTER} textBgColor={red} />
               </div>
             </div>
           </div>

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -12,8 +12,21 @@ import pink from "@/shared/assets/images/heros/textBgColors/pink.webp";
 import cls from './HeroContainer.module.scss';
 import useKeyboardNavigation from './useKeyboardNavigation';
 
-
+/**
+ * group={selectedHero.group}
+        groupTextBg={selectedHero.groupTextBg}
+        heroColor={selectedHero.heroColor}
+        heroImg={selectedHero.img}
+        heroName={selectedHero.title}
+        heroDescription={selectedHero.description}
+        leftArrowLink={prevHeroLink}
+        rightArrowLink={nextHeroLink}
+        heroGif={selectedHero.imgGif}
+        xLink={RoutePaths.HEROES}
+ */
 type Props = {
+  group: string;
+  groupTextBg: string;
   heroImg: string;
   heroGif: string;
   heroName: string;
@@ -33,6 +46,7 @@ const HeroContainer = (props: Props) => {
     rightArrowLink,
     xLink,
     heroName,
+    group
   } = props;
 
   useKeyboardNavigation({
@@ -134,6 +148,7 @@ const HeroContainer = (props: Props) => {
       </div>
   );
 };
+
 
 enum HeroType {
   FIGHTER = 'FIGHTER',

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -35,60 +35,6 @@ const HeroContainer = (props: Props) => {
     heroName,
   } = props;
 
-enum HeroType {
-  FIGHTER = 'FIGHTER',
-  MERGER = 'MERGER',
-  INTELLECTUAL = 'INTELLECTUAL',
-  MIRROR_LOOKER = 'MIRROR_LOOKER'
-}
-function defineHeroGroupLabelText(heroType: HeroType) {
-  switch (heroType) {
-    case 'FIGHTER':
-      return 'TORJUJAT // RETROFLEKTIO';
-    case 'MERGER':
-      return 'SULAUTUJAT // KONFLUENSSI';
-    case 'INTELLECTUAL':
-      return 'ÄLYLLISTÄJÄT // EGOTISMI';
-    case 'MIRROR_LOOKER':
-      return 'PEILAAJAT // PROJEKTIO';
-    default:
-      return '';
-  }
-}
-function defineHeroGroupLabelBg(heroType: HeroType) {
-  switch (heroType) {
-    case 'FIGHTER':
-      return red;
-    case 'MERGER':
-      return pink;
-    case 'INTELLECTUAL':
-      return darkBlue;
-    case 'MIRROR_LOOKER':
-      return orange;
-    default:
-      return null;
-  }
-}
-
-type HeroGroupLabelProps = Readonly<{
-  heroType: HeroType
-}>;
-function HeroGroupLabel({heroType}: HeroGroupLabelProps) {
-  const labelText = defineHeroGroupLabelText(heroType);
-  const labelBg = defineHeroGroupLabelBg(heroType);
-
-  return(
-    <div className={`${cls.heroGroupLabel}`}>
-      <h3
-          className={cls.heroGroupLabelTitle}
-          style={labelBg ? {backgroundImage: `url(${labelBg.src})`} : undefined} 
-      >
-        <span>{labelText}</span>
-      </h3>
-  </div>
-  );
-}
-
   useKeyboardNavigation({
     leftArrowLink,
     rightArrowLink,
@@ -188,5 +134,59 @@ function HeroGroupLabel({heroType}: HeroGroupLabelProps) {
       </div>
   );
 };
+
+enum HeroType {
+  FIGHTER = 'FIGHTER',
+  MERGER = 'MERGER',
+  INTELLECTUAL = 'INTELLECTUAL',
+  MIRROR_LOOKER = 'MIRROR_LOOKER'
+}
+function defineHeroGroupLabelText(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return 'TORJUJAT // RETROFLEKTIO';
+    case 'MERGER':
+      return 'SULAUTUJAT // KONFLUENSSI';
+    case 'INTELLECTUAL':
+      return 'ÄLYLLISTÄJÄT // EGOTISMI';
+    case 'MIRROR_LOOKER':
+      return 'PEILAAJAT // PROJEKTIO';
+    default:
+      return '';
+  }
+}
+function defineHeroGroupLabelBg(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return red;
+    case 'MERGER':
+      return pink;
+    case 'INTELLECTUAL':
+      return darkBlue;
+    case 'MIRROR_LOOKER':
+      return orange;
+    default:
+      return null;
+  }
+}
+
+type HeroGroupLabelProps = Readonly<{
+  heroType: HeroType
+}>;
+function HeroGroupLabel({heroType}: HeroGroupLabelProps) {
+  const labelText = defineHeroGroupLabelText(heroType);
+  const labelBg = defineHeroGroupLabelBg(heroType);
+
+  return(
+    <div className={`${cls.heroGroupLabel}`}>
+      <h3
+          className={cls.heroGroupLabelTitle}
+          style={labelBg ? {backgroundImage: `url(${labelBg.src})`} : undefined} 
+      >
+        <span>{labelText}</span>
+      </h3>
+  </div>
+  );
+}
 
 export default HeroContainer;

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -5,12 +5,9 @@ import { classNames, Mods } from '@/shared/lib/classNames/classNames';
 import leftArrow from '@/shared/assets/images/heros/hero-container/leftArrow.svg';
 import rightArrow from '@/shared/assets/images/heros/hero-container/rightArrow.svg';
 import useSizes from '@/shared/lib/hooks/useSizes';
-import red from "@/shared/assets/images/heros/textBgColors/red.webp";
-import darkBlue from "@/shared/assets/images/heros/textBgColors/dark-blue.webp";
-import orange from "@/shared/assets/images/heros/textBgColors/orange.webp";
-import pink from "@/shared/assets/images/heros/textBgColors/pink.webp";
 import cls from './HeroContainer.module.scss';
 import useKeyboardNavigation from './useKeyboardNavigation';
+import HeroGroupLabel from '../HeroGroupLabel/HeroGroupLabel';
 
 /**
  * group={selectedHero.group}
@@ -64,8 +61,6 @@ const HeroContainer = (props: Props) => {
     [cls.isDesktop]: isDesktopSize,
     [cls.isWidescreen]: isWidescreenSize,
   };
-
-  const heroType = convertHeroGroupToHeroType(group);
 
   return (
       <div className={classNames(cls.componentWrapper, combinedModCss)}>
@@ -134,7 +129,7 @@ const HeroContainer = (props: Props) => {
                 <div className={cls.heroDescription}>
                   <h3>{heroDescription}</h3>
                 </div>
-                {heroType && <HeroGroupLabel heroType={heroType} />}
+                <HeroGroupLabel group={group} />
               </div>
             </div>
           </div>
@@ -150,75 +145,5 @@ const HeroContainer = (props: Props) => {
       </div>
   );
 };
-
-function convertHeroGroupToHeroType(group: string) {
-  switch (group) {
-    case 'TORJUJAT // RETROFLEKTIO':
-      return HeroType.FIGHTER;
-    case 'SULAUTUJAT // KONFLUENSSI':
-      return HeroType.MERGER;
-    case 'ÄLYLLISTÄJÄT // EGOTISMI':
-      return HeroType.INTELLECTUAL;
-    case 'PEILAAJAT // PROJEKTIO':
-      return HeroType.MIRROR_LOOKER;
-    default:
-      return null;
-  }
-}
-
-
-enum HeroType {
-  FIGHTER = 'FIGHTER',
-  MERGER = 'MERGER',
-  INTELLECTUAL = 'INTELLECTUAL',
-  MIRROR_LOOKER = 'MIRROR_LOOKER'
-}
-function defineHeroGroupLabelText(heroType: HeroType) {
-  switch (heroType) {
-    case 'FIGHTER':
-      return 'TORJUJAT // RETROFLEKTIO';
-    case 'MERGER':
-      return 'SULAUTUJAT // KONFLUENSSI';
-    case 'INTELLECTUAL':
-      return 'ÄLYLLISTÄJÄT // EGOTISMI';
-    case 'MIRROR_LOOKER':
-      return 'PEILAAJAT // PROJEKTIO';
-    default:
-      return '';
-  }
-}
-function defineHeroGroupLabelBg(heroType: HeroType) {
-  switch (heroType) {
-    case 'FIGHTER':
-      return red;
-    case 'MERGER':
-      return pink;
-    case 'INTELLECTUAL':
-      return darkBlue;
-    case 'MIRROR_LOOKER':
-      return orange;
-    default:
-      return null;
-  }
-}
-
-type HeroGroupLabelProps = Readonly<{
-  heroType: HeroType
-}>;
-function HeroGroupLabel({heroType}: HeroGroupLabelProps) {
-  const labelText = defineHeroGroupLabelText(heroType);
-  const labelBg = defineHeroGroupLabelBg(heroType);
-
-  return(
-    <div className={`${cls.heroGroupLabel}`}>
-      <h3
-          className={cls.heroGroupLabelTitle}
-          style={labelBg ? {backgroundImage: `url(${labelBg.src})`} : undefined} 
-      >
-        <span>{labelText}</span>
-      </h3>
-  </div>
-  );
-}
 
 export default HeroContainer;

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -149,6 +149,21 @@ const HeroContainer = (props: Props) => {
   );
 };
 
+function convertHeroGroupToHeroType(group: string) {
+  switch (group) {
+    case 'TORJUJAT // RETROFLEKTIO':
+      return HeroType.FIGHTER;
+    case 'SULAUTUJAT // KONFLUENSSI':
+      return HeroType.MERGER;
+    case 'ÄLYLLISTÄJÄT // EGOTISMI':
+      return HeroType.INTELLECTUAL;
+    case 'PEILAAJAT // PROJEKTIO':
+      return HeroType.MIRROR_LOOKER;
+    default:
+      return null;
+  }
+}
+
 
 enum HeroType {
   FIGHTER = 'FIGHTER',

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -41,6 +41,20 @@ enum HeroType {
   INTELLECTUAL = 'INTELLECTUAL',
   MIRROR_LOOKER = 'MIRROR_LOOKER'
 }
+function defineHeroGroupLabelText(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return 'TORJUJAT // RETROFLEKTIO';
+    case 'MERGER':
+      return 'SULAUTUJAT // KONFLUENSSI';
+    case 'INTELLECTUAL':
+      return 'ÄLYLLISTÄJÄT // EGOTISMI';
+    case 'MIRROR_LOOKER':
+      return 'PEILAAJAT // PROJEKTIO';
+    default:
+      return '';
+  }
+}
 
 
 const heroGroups = [

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -1,13 +1,14 @@
 'use client';
-import Image from 'next/image';
+import Image, { StaticImageData } from 'next/image';
 import Link from 'next/link';
-
-
 import { classNames, Mods } from '@/shared/lib/classNames/classNames';
 import leftArrow from '@/shared/assets/images/heros/hero-container/leftArrow.svg';
 import rightArrow from '@/shared/assets/images/heros/hero-container/rightArrow.svg';
 import useSizes from '@/shared/lib/hooks/useSizes';
-
+import red from "@/shared/assets/images/heros/textBgColors/red.webp";
+import darkBlue from "@/shared/assets/images/heros/textBgColors/dark-blue.webp";
+import orange from "@/shared/assets/images/heros/textBgColors/orange.webp";
+import pink from "@/shared/assets/images/heros/textBgColors/pink.webp";
 import cls from './HeroContainer.module.scss';
 import useKeyboardNavigation from './useKeyboardNavigation';
 
@@ -34,6 +35,20 @@ const HeroContainer = (props: Props) => {
     heroName,
   } = props;
 
+enum HeroType {
+  FIGHTER = 'FIGHTER',
+  MERGER = 'MERGER',
+  INTELLECTUAL = 'INTELLECTUAL',
+  MIRROR_LOOKER = 'MIRROR_LOOKER'
+}
+
+
+const heroGroups = [
+  { group: "TORJUJAT // RETROFLEKTIO", textBgColor: red },
+  { group: "SULAUTUJAT // KONFLUENSSI", textBgColor: pink },
+  { group: "ÄLYLLISTÄJÄT // EGOTISMI", textBgColor: darkBlue },
+  { group: "PEILAAJAT // PROJEKTIO", textBgColor: orange }
+];
 
 
   useKeyboardNavigation({

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -1,5 +1,5 @@
 'use client';
-import Image, { StaticImageData } from 'next/image';
+import Image from 'next/image';
 import Link from 'next/link';
 import { classNames, Mods } from '@/shared/lib/classNames/classNames';
 import leftArrow from '@/shared/assets/images/heros/hero-container/leftArrow.svg';
@@ -9,18 +9,6 @@ import cls from './HeroContainer.module.scss';
 import useKeyboardNavigation from './useKeyboardNavigation';
 import HeroGroupLabel from '../HeroGroupLabel/HeroGroupLabel';
 
-/**
- * group={selectedHero.group}
-        groupTextBg={selectedHero.groupTextBg}
-        heroColor={selectedHero.heroColor}
-        heroImg={selectedHero.img}
-        heroName={selectedHero.title}
-        heroDescription={selectedHero.description}
-        leftArrowLink={prevHeroLink}
-        rightArrowLink={nextHeroLink}
-        heroGif={selectedHero.imgGif}
-        xLink={RoutePaths.HEROES}
- */
 type Props = {
   group: string;
   groupTextBg: string;

--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -55,33 +55,39 @@ function defineHeroGroupLabelText(heroType: HeroType) {
       return '';
   }
 }
+function defineHeroGroupLabelBg(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return red;
+    case 'MERGER':
+      return pink;
+    case 'INTELLECTUAL':
+      return darkBlue;
+    case 'MIRROR_LOOKER':
+      return orange;
+    default:
+      return null;
+  }
+}
 
 type HeroGroupLabelProps = Readonly<{
-  heroType: HeroType,
-  textBgColor: StaticImageData
+  heroType: HeroType
 }>;
-function HeroGroupLabel({heroType, textBgColor}: HeroGroupLabelProps) {
+function HeroGroupLabel({heroType}: HeroGroupLabelProps) {
   const labelText = defineHeroGroupLabelText(heroType);
+  const labelBg = defineHeroGroupLabelBg(heroType);
 
   return(
     <div className={`${cls.heroGroupLabel}`}>
       <h3
           className={cls.heroGroupLabelTitle}
-          style={{backgroundImage: `url(${textBgColor.src})`}}
+          style={labelBg ? {backgroundImage: `url(${labelBg.src})`} : undefined} 
       >
         <span>{labelText}</span>
       </h3>
   </div>
   );
 }
-
-const heroGroups = [
-  { group: "TORJUJAT // RETROFLEKTIO", textBgColor: red },
-  { group: "SULAUTUJAT // KONFLUENSSI", textBgColor: pink },
-  { group: "ÄLYLLISTÄJÄT // EGOTISMI", textBgColor: darkBlue },
-  { group: "PEILAAJAT // PROJEKTIO", textBgColor: orange }
-];
-
 
   useKeyboardNavigation({
     leftArrowLink,
@@ -166,7 +172,7 @@ const heroGroups = [
                 <div className={cls.heroDescription}>
                   <h3>{heroDescription}</h3>
                 </div>
-                <HeroGroupLabel heroType={HeroType.FIGHTER} textBgColor={red} />
+                <HeroGroupLabel heroType={HeroType.FIGHTER} />
               </div>
             </div>
           </div>

--- a/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.module.scss
@@ -1,0 +1,23 @@
+.heroGroupLabel{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    flex-direction: row;
+  
+    &Title{
+      background-repeat: no-repeat;
+      background-position: center center;
+      background-attachment: scroll;
+      background-size: cover;
+      padding: 4vw;
+      text-shadow: 1px 1px 2px black;
+  
+      & span {
+        font-size: calc(12px + 0.8vw);
+        display: inline-block;
+        transform: translateX(calc(12px + 0.2vw));
+        hyphens: manual;
+      }
+    }
+  }

--- a/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.tsx
@@ -1,0 +1,80 @@
+import red from "@/shared/assets/images/heros/textBgColors/red.webp";
+import darkBlue from "@/shared/assets/images/heros/textBgColors/dark-blue.webp";
+import orange from "@/shared/assets/images/heros/textBgColors/orange.webp";
+import pink from "@/shared/assets/images/heros/textBgColors/pink.webp";
+import cls from './HeroGroupLabel.module.scss';
+
+type HeroGroupLabelProps = Readonly<{
+  group: string
+}>;
+export default function HeroGroupLabel({ group }: HeroGroupLabelProps) {
+  const heroType = convertHeroGroupToHeroType(group);
+
+  if(!heroType)
+    return <p>Could not determine the hero type </p>
+
+  const labelText = defineHeroGroupLabelText(heroType);
+  const labelBg = defineHeroGroupLabelBg(heroType);
+
+  return(
+    <div className={cls.heroGroupLabel}>
+      <h3
+          className={cls.heroGroupLabelTitle}
+          style={labelBg ? {backgroundImage: `url(${labelBg.src})`} : undefined} 
+      >
+        <span>{labelText}</span>
+      </h3>
+    </div>
+  );
+}
+
+enum HeroType {
+  FIGHTER = 'FIGHTER',
+  MERGER = 'MERGER',
+  INTELLECTUAL = 'INTELLECTUAL',
+  MIRROR_LOOKER = 'MIRROR_LOOKER'
+}
+
+function defineHeroGroupLabelText(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return 'TORJUJAT // RETROFLEKTIO';
+    case 'MERGER':
+      return 'SULAUTUJAT // KONFLUENSSI';
+    case 'INTELLECTUAL':
+      return 'ÄLYLLISTÄJÄT // EGOTISMI';
+    case 'MIRROR_LOOKER':
+      return 'PEILAAJAT // PROJEKTIO';
+    default:
+      return '';
+  }
+}
+function defineHeroGroupLabelBg(heroType: HeroType) {
+  switch (heroType) {
+    case 'FIGHTER':
+      return red;
+    case 'MERGER':
+      return pink;
+    case 'INTELLECTUAL':
+      return darkBlue;
+    case 'MIRROR_LOOKER':
+      return orange;
+    default:
+      return null;
+  }
+}
+
+function convertHeroGroupToHeroType(group: string) {
+  switch (group) {
+    case 'TORJUJAT // RETROFLEKTIO':
+      return HeroType.FIGHTER;
+    case 'SULAUTUJAT // KONFLUENSSI':
+      return HeroType.MERGER;
+    case 'ÄLYLLISTÄJÄT // EGOTISMI':
+      return HeroType.INTELLECTUAL;
+    case 'PEILAAJAT // PROJEKTIO':
+      return HeroType.MIRROR_LOOKER;
+    default:
+      return null;
+  }
+}

--- a/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroGroupLabel/HeroGroupLabel.tsx
@@ -4,9 +4,27 @@ import orange from "@/shared/assets/images/heros/textBgColors/orange.webp";
 import pink from "@/shared/assets/images/heros/textBgColors/pink.webp";
 import cls from './HeroGroupLabel.module.scss';
 
+
 type HeroGroupLabelProps = Readonly<{
+  /**
+   * Group to which the Hero belongs to
+   */
   group: string
 }>;
+/**
+ * Displays label containing a hero group to which the hero belongs to.
+ * 
+ * Outlook of the label will be defined based on the group value, which should be one of these:
+ * - TORJUJAT // RETROFLEKTIO
+ * - SULAUTUJAT // KONFLUENSSI
+ * - ÄLYLLISTÄJÄT // EGOTISMI
+ * - PEILAAJAT // PROJEKTIO
+ * 
+ * If the group has some other value an error text will be displayed instead of the label
+ * 
+ * @param Props
+ * @returns 
+ */
 export default function HeroGroupLabel({ group }: HeroGroupLabelProps) {
   const heroType = convertHeroGroupToHeroType(group);
 
@@ -28,6 +46,9 @@ export default function HeroGroupLabel({ group }: HeroGroupLabelProps) {
   );
 }
 
+/**
+ * Type of the hero
+ */
 enum HeroType {
   FIGHTER = 'FIGHTER',
   MERGER = 'MERGER',
@@ -35,6 +56,12 @@ enum HeroType {
   MIRROR_LOOKER = 'MIRROR_LOOKER'
 }
 
+/**
+ * Determines text for the provided hero type
+ * 
+ * @param heroType type of the hero
+ * @returns text for the corresponding hero type or empty string if the hero type is unknown
+ */
 function defineHeroGroupLabelText(heroType: HeroType) {
   switch (heroType) {
     case 'FIGHTER':
@@ -49,6 +76,12 @@ function defineHeroGroupLabelText(heroType: HeroType) {
       return '';
   }
 }
+/**
+ * Determines the background image corresponding to the hero type
+ * 
+ * @param heroType type of the hero
+ * @returns background image if it exists for the type or null if not
+ */
 function defineHeroGroupLabelBg(heroType: HeroType) {
   switch (heroType) {
     case 'FIGHTER':
@@ -64,6 +97,18 @@ function defineHeroGroupLabelBg(heroType: HeroType) {
   }
 }
 
+/**
+ * Convert hero group to hero type.
+ * 
+ * Notice that the group should be one of the following:
+ * - TORJUJAT // RETROFLEKTIO
+ * - SULAUTUJAT // KONFLUENSSI
+ * - ÄLYLLISTÄJÄT // EGOTISMI
+ * - PEILAAJAT // PROJEKTIO
+ * 
+ * @param group hero group to convert
+ * @returns corresponding hero type or null if the group is unknown
+ */
 function convertHeroGroupToHeroType(group: string) {
   switch (group) {
     case 'TORJUJAT // RETROFLEKTIO':


### PR DESCRIPTION
1. Add new HeroGroupLabel component
2. Add use of the component to the hero page

I have added also _HeroType_ enum, which is basically the same thing as the _group_ string from the [heroes array](https://github.com/Alt-Org/Altzone-WebPages/blob/main/frontend-next-migration/src/entities/Hero/model/heroes.ts) since there there are no type or enum for the field, which could lead to errors. I would suggest to add some type or enum for the _group_ field in the future.

I have also changed the type of HeroContainer component by adding group and groupTextBg properties, since I needed this info for the label component and this info was already passed in the page

Closes #55 