### PR TITLE
fix bug with cropping group label for hero page

### DIFF
--- a/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroContainerTempByLeo/HeroContainer.tsx
@@ -117,10 +117,10 @@ const HeroContainer = (props: Props) => {
                 <div className={cls.heroDescription}>
                   <h3>{heroDescription}</h3>
                 </div>
-                <HeroGroupLabel group={group} />
               </div>
             </div>
           </div>
+          <HeroGroupLabel group={group} />
         </div>
 
         <Link


### PR DESCRIPTION
The bug was caused by the container paddings to which the label component was placed. 

Bug was fixed by moving the label from the container couple levels up

Closes #62 