### PR TITLE
Add environment variables to CI build step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,10 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: ./frontend-next-migration
+        env:
+          NEXT_PUBLIC_API_LINK: ${{ secrets.NEXT_PUBLIC_API_LINK }}
+          NEXT_PUBLIC_API_DOMAIN: ${{ secrets.NEXT_PUBLIC_API_DOMAIN }}
+          NEXT_PUBLIC_LOCAL_HOST: ${{ secrets.NEXT_PUBLIC_LOCAL_HOST }}
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
This change ensures that necessary environment variables are available during the CI build process. It adds NEXT_PUBLIC_API_LINK, NEXT_PUBLIC_API_DOMAIN, and NEXT_PUBLIC_LOCAL_HOST to the build step.