### PR TITLE
Sakari/enc/fix register page

### DIFF
--- a/frontend-next-migration/src/entities/Auth/types/authUser.d.ts
+++ b/frontend-next-migration/src/entities/Auth/types/authUser.d.ts
@@ -1,7 +1,7 @@
-import {IPlayer} from "@/entities/User";
-import {IProfile} from "@/entities/Profile";
+import { IPlayer } from "@/entities/User";
+import { IProfile } from "@/entities/Profile";
 
-export type IPlayerRegisterPartDto = Pick<IPlayer, "name" | "backpackCapacity" | "uniqueIdentifier">
+export type IPlayerRegisterPartDto = Pick<IPlayer, "name" | "backpackCapacity" | "uniqueIdentifier" | "above13">
 
 export type IUserRegisterDto = Pick<IProfile, 'username'> & {
     password: string,
@@ -11,7 +11,7 @@ export type IUserRegisterDto = Pick<IProfile, 'username'> & {
 
 export type IUserLoginDto = Pick<IProfile, 'username'> & { password: string };
 
-export type ILoginResponse =  & IProfile & {
+export type ILoginResponse = & IProfile & {
     accessToken: string
 }
 
@@ -28,5 +28,5 @@ type AccessTokenInfo = {
 export type AuthUserSchema = {
     profile?: IProfile,
     accessTokenInfo?: AccessTokenInfo
-    isSessionExpired : boolean
+    isSessionExpired: boolean
 }

--- a/frontend-next-migration/src/entities/User/types/player.d.ts
+++ b/frontend-next-migration/src/entities/User/types/player.d.ts
@@ -5,4 +5,5 @@ export type IPlayer = {
         uniqueIdentifier: string,
         profile_id: string,
         clan_id: string
+        above13: boolean,
 }

--- a/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
+++ b/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
@@ -22,26 +22,23 @@ export const useRegisterForm = (toLoginPage: string) => {
             password: fieldValues.password,
             repeatPassword: fieldValues.password,
             Player: {
-                uniqueIdentifier: fieldValues.uniqueIdentifier,
-                backpackCapacity: fieldValues.backpackCapacity,
-                name: fieldValues.name,
+                uniqueIdentifier: fieldValues.username,
+                backpackCapacity: 100,
+                name: fieldValues.username,
                 above13: fieldValues.ageConsent,
             },
         };
-        console.log(ObjectToBeSent);
         await regist(ObjectToBeSent);
     }
 
     useEffect(() => {
         if (data) {
             toast.success('Tili on luotu!');
-            console.log(data);
             return;
         }
 
         if (error) {
             // @ts-ignore
-            console.log(error);
             toast.error(error?.data?.message[0] ?? error?.data?.message);
             return;
         }

--- a/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
+++ b/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
@@ -1,9 +1,9 @@
-import {FieldValues, useForm} from 'react-hook-form';
+import { FieldValues, useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ValidationRegisterSchema } from '../validations';
 import { IUserRegisterDto, useRegisterMutation } from '@/entities/Auth';
-import {useEffect} from "react";
-import {toast} from "react-toastify";
+import { useEffect } from "react";
+import { toast } from "react-toastify";
 
 export const useRegisterForm = (toLoginPage: string) => {
     const {
@@ -25,23 +25,27 @@ export const useRegisterForm = (toLoginPage: string) => {
                 uniqueIdentifier: fieldValues.uniqueIdentifier,
                 backpackCapacity: fieldValues.backpackCapacity,
                 name: fieldValues.name,
+                above13: fieldValues.ageConsent,
             },
         };
+        console.log(ObjectToBeSent);
         await regist(ObjectToBeSent);
     }
 
     useEffect(() => {
         if (data) {
             toast.success('Tili on luotu!');
+            console.log(data);
             return;
         }
 
         if (error) {
             // @ts-ignore
+            console.log(error);
             toast.error(error?.data?.message[0] ?? error?.data?.message);
             return;
         }
-    }, [isLoading, data , error]);
+    }, [isLoading, data, error]);
 
 
     return {

--- a/frontend-next-migration/src/features/AuthByUsername/ui/RegisterForm/RegisterForm.tsx
+++ b/frontend-next-migration/src/features/AuthByUsername/ui/RegisterForm/RegisterForm.tsx
@@ -3,8 +3,8 @@ import { CustomForm } from "@/shared/ui/CustomForm";
 import cls from "./RegisterForm.module.scss";
 import { AppLink, AppLinkTheme } from "@/shared/ui/AppLink/AppLink";
 import { useRegisterForm } from "../../model/useRegisterForm";
-import {useParams} from "next/navigation";
-import {useClientTranslation} from "@/shared/i18n";
+import { useParams } from "next/navigation";
+import { useClientTranslation } from "@/shared/i18n";
 
 type Props = {
     toLoginPage: string;
@@ -14,8 +14,7 @@ export const RegisterForm = ({ toLoginPage }: Props) => {
 
     const params = useParams();
     const lng = params.lng as string;
-    const {t} = useClientTranslation(lng, "auth");
-
+    const { t } = useClientTranslation(lng, "auth");
 
     const {
         register,
@@ -39,7 +38,7 @@ export const RegisterForm = ({ toLoginPage }: Props) => {
 
             <CustomForm.InputField
                 key={"password"}
-                error={errors?.password?.message  && t(`${errors?.password?.message}`)}
+                error={errors?.password?.message && t(`${errors?.password?.message}`)}
                 label={t("password")}
                 inputProps={{ ...register('password'), type: "password", required: true }}
             />
@@ -51,32 +50,11 @@ export const RegisterForm = ({ toLoginPage }: Props) => {
                 inputProps={{ ...register('repeatPassword'), type: "password", required: true }}
             />
 
-            <CustomForm.InputField
-                key={"name"}
-                error={errors?.name?.message && t(`${errors?.name?.message}`)}
-                label={t('name')}
-                inputProps={{ ...register('name'), required: true }}
-            />
-
-            <CustomForm.InputField
-                key={"backpackCapacity"}
-                error={errors?.backpackCapacity?.message && t(`${errors?.backpackCapacity?.message}`)}
-                label={t("backpackCapacity")}
-                inputProps={{ ...register('backpackCapacity'), required: true, type: "number" }}
-            />
-
-            <CustomForm.InputField
-                key={"uniqueIdentifier"}
-                error={errors?.uniqueIdentifier?.message && t(`${errors?.uniqueIdentifier?.message}`)}
-                label={t("uniqueIdentifier")}
-                inputProps={{ ...register('uniqueIdentifier'), required: true }}
-            />
-
             <CustomForm.Checkbox
                 key={"ageConsent"}
                 error={errors?.ageConsent?.message && t(`${errors?.ageConsent?.message}`)}
                 // todo add i18n
-                label={t("I confirm that I am at least 13 years old and I agree to the collection of necessary data.")}
+                label={t("age_Consent")}
                 inputProps={{ ...register('ageConsent', { required: true }) }}
             />
 

--- a/frontend-next-migration/src/features/AuthByUsername/ui/RegisterForm/RegisterForm.tsx
+++ b/frontend-next-migration/src/features/AuthByUsername/ui/RegisterForm/RegisterForm.tsx
@@ -53,7 +53,6 @@ export const RegisterForm = ({ toLoginPage }: Props) => {
             <CustomForm.Checkbox
                 key={"ageConsent"}
                 error={errors?.ageConsent?.message && t(`${errors?.ageConsent?.message}`)}
-                // todo add i18n
                 label={t("age_Consent")}
                 inputProps={{ ...register('ageConsent', { required: true }) }}
             />

--- a/frontend-next-migration/src/shared/i18n/locales/en/auth.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/auth.json
@@ -10,32 +10,23 @@
   "send": "Send",
   "text_to_register": "Don't have an account? Register",
   "text_to_login": "Already have an account? Log In",
-
   "username_required_error": "Enter your username",
   "username_min_error": "Username must be at least 3 characters long",
   "username_max_error": "Username must be at most 15 characters long",
   "username_regex_error": "Username can only contain letters and numbers",
-
   "password_required_error": "Enter your password",
   "password_again_required_error": "Confirm your password",
   "password_again_is_not_same_error": "Passwords must match",
   "password_min_error": "Password must be at least 6 characters long",
   "password_max_error": "Password must be at most 30 characters long",
-
   "name_min_error": "Name must be at least 3 characters long",
   "name_max_error": "Name must be at most 20 characters long",
   "name_regex_error": "Name can only contain letters and spaces",
-
-
-
   "auth-login-head-title": "Log in",
   "auth-login-head-description": "Log in to your Altzone account and join our gaming community.",
   "auth-login-head-keywords": "altzone, game, gaming community, log in, login, membership",
-
-
   "auth-register-head-title": "Register",
   "auth-register-head-description": "Register for an Altzone account and join our gaming community.",
-  "auth-register-head-keywords": "altzone, game, gaming community, register, membership"
-
-
+  "auth-register-head-keywords": "altzone, game, gaming community, register, membership",
+  "age_Consent": "I confirm that I am over 13 years old or I have my parents' permission to participate in the game's social activity."
 }

--- a/frontend-next-migration/src/shared/i18n/locales/en/auth.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/auth.json
@@ -22,6 +22,7 @@
   "name_min_error": "Name must be at least 3 characters long",
   "name_max_error": "Name must be at most 20 characters long",
   "name_regex_error": "Name can only contain letters and spaces",
+  "age_consent_required_error": "Confirm that you are over 13 or have your parents' permission.",
   "auth-login-head-title": "Log in",
   "auth-login-head-description": "Log in to your Altzone account and join our gaming community.",
   "auth-login-head-keywords": "altzone, game, gaming community, log in, login, membership",

--- a/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
@@ -19,6 +19,7 @@
   "name_min_error": "Nimen on oltava vähintään 3 merkkiä pitkä",
   "name_max_error": "Nimen on oltava enintään 20 merkkiä pitkä",
   "name_regex_error": "Nimi saa sisältää vain kirjaimia ja välilyöntejä",
+  "age_consent_required_error": "Vahvista, että olet yli 13-vuotias tai sinulla on vanhempiesi lupa.",
   "auth-login-head-title": "Kirjaudu sisään",
   "auth-login-head-description": "Kirjaudu sisään Altzone-tilillesi ja liity peliyhteisöömme.",
   "auth-login-head-keywords": "altzone, peli, peliyhteisö, kirjaudu sisään, jäsenyys",

--- a/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
@@ -2,38 +2,28 @@
   "log_in": "Kirjaudu sisään",
   "register": "Rekisteröidy",
   "username": "Käyttäjänimi",
-  "name": "Name",
-  "backpackCapacity": "Reppuvarasto (Backpack capacity)",
-  "uniqueIdentifier": "Yksilöllinen tunniste (Unique identifier)",
   "password": "Salasana",
   "password_again": "Toista salasana",
   "send": "Lähetä",
   "text_to_register": "Eikö sinulla ole tiliä? Rekisteröidy",
   "text_to_login": "Onko sinulla jo tili? Kirjaudu sisään",
-
-
   "username_required_error": "Syötä käyttäjänimesi ",
   "username_min_error": "Käyttäjänimen on oltava vähintään 3 merkkiä pitkä",
   "username_max_error": "Käyttäjänimen on oltava enintään 15 merkkiä pitkä",
   "username_regex_error": "Käyttäjänimi saa sisältää vain kirjaimia ja numeroita",
-
   "password_required_error": "Syötä käyttäjänimesi",
   "password_again_required_error": "Vahvista salasanasi",
   "password_again_is_not_same_error": "Salasanojen on täsmättävä",
   "password_min_error": "Salasanan on oltava vähintään 6 merkkiä pitkä",
   "password_max_error": "Salasanan on oltava enintään 30 merkkiä pitkä",
-
   "name_min_error": "Nimen on oltava vähintään 3 merkkiä pitkä",
   "name_max_error": "Nimen on oltava enintään 20 merkkiä pitkä",
   "name_regex_error": "Nimi saa sisältää vain kirjaimia ja välilyöntejä",
-
-
   "auth-login-head-title": "Kirjaudu sisään",
   "auth-login-head-description": "Kirjaudu sisään Altzone-tilillesi ja liity peliyhteisöömme.",
   "auth-login-head-keywords": "altzone, peli, peliyhteisö, kirjaudu sisään, jäsenyys",
-
   "auth-register-head-title": "Rekisteröidy",
   "auth-register-head-description": "Rekisteröidy Altzone-tilille ja liity peliyhteisöömme.",
-  "auth-register-head-keywords": "altzone, peli, peliyhteisö, rekisteröidy, jäsenyys"
-
+  "auth-register-head-keywords": "altzone, peli, peliyhteisö, rekisteröidy, jäsenyys",
+  "age_Consent": "Vakuutan että olen yli 13 vuotias tai minulla on vanhempieni lupa osallistua pelin sosiaaliseen toimintaan"
 }

--- a/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/auth.json
@@ -25,5 +25,5 @@
   "auth-register-head-title": "Rekisteröidy",
   "auth-register-head-description": "Rekisteröidy Altzone-tilille ja liity peliyhteisöömme.",
   "auth-register-head-keywords": "altzone, peli, peliyhteisö, rekisteröidy, jäsenyys",
-  "age_Consent": "Vakuutan että olen yli 13 vuotias tai minulla on vanhempieni lupa osallistua pelin sosiaaliseen toimintaan"
+  "age_Consent": "Vakuutan että olen yli 13 vuotias tai minulla on vanhempieni lupa osallistua pelin sosiaaliseen toimintaan."
 }


### PR DESCRIPTION
Requested changes done on issue #76
> * [x]  we should remove fields: name, backpack capacity and unique identifier
> * [x]  confirming text should be changed to  -> "vakuutan että olen yli 13 vuotias tai minulla on vanhempieni lupa osallistua pelin sosiaaliseen toimintaan"'
> * [x]  confirming text should be translated
> 
> ![image](https://private-user-images.githubusercontent.com/61798137/361354433-009e7dd1-e548-42ed-a7da-a4aa3f70ee98.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MjY4MzI1NjMsIm5iZiI6MTcyNjgzMjI2MywicGF0aCI6Ii82MTc5ODEzNy8zNjEzNTQ0MzMtMDA5ZTdkZDEtZTU0OC00MmVkLWE3ZGEtYTRhYTNmNzBlZTk4LnBuZz9YLUFtei1BbGdvcml0aG09QVdTNC1ITUFDLVNIQTI1NiZYLUFtei1DcmVkZW50aWFsPUFLSUFWQ09EWUxTQTUzUFFLNFpBJTJGMjAyNDA5MjAlMkZ1cy1lYXN0LTElMkZzMyUyRmF3czRfcmVxdWVzdCZYLUFtei1EYXRlPTIwMjQwOTIwVDExMzc0M1omWC1BbXotRXhwaXJlcz0zMDAmWC1BbXotU2lnbmF0dXJlPWM2NTgyYjU5NmQ1N2YwNGI2ZDFjMzJhNjA3MTIwMTIzYWQ1NWJiMDAzNjU5OWFkNTgxMjUzZWQ1NmFiZGVmYWYmWC1BbXotU2lnbmVkSGVhZGVycz1ob3N0In0.-9qBhnTFQDHpm44uohScLXVhhIpcBBXRNFbDhVAGO3g)

**Stuff done:**

- Updated consent field text locales and fixed on submit error text
- Removed fields from form: name, backpack capacity and unique identifier (_API requires backpackCapacity, uniqueIdentifier and name fields to be filled. Used username as uniqueIdentifier and name to POST 201._)
- Updated auth model/schema to include above13 boolean
- Tested to be working
- API requires backpackCapacity, uniqueIdentifier and name fields to be filled. Used username as uniqueIdentifier and name to post 201.
