### PR TITLE
aku/bug/#80-fix-clickable-border

### DIFF
--- a/frontend-next-migration/src/entities/Hero/ui/HeroCard/HeroCard.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroCard/HeroCard.module.scss
@@ -44,6 +44,7 @@
 }
 
 .HeroDiv {
+  pointer-events: all;
   cursor: pointer;
   width: 100%;
   height: 100%;

--- a/frontend-next-migration/src/shared/ui/ClickableBorder/ClickableBorder.module.scss
+++ b/frontend-next-migration/src/shared/ui/ClickableBorder/ClickableBorder.module.scss
@@ -2,6 +2,7 @@
   border-image-slice: 0.01 fill;
   border-image-repeat: stretch;
   display: block;
+  pointer-events:none;  
 }
 
 .hovered {


### PR DESCRIPTION
## 📄 **Pull Request Overview**

**Issue Number**: #80 

## 🔧 **Changes Made**

Added 2 scss rows that fixed the issue. Issue was that the clickableBorder's padding was invisible but it made the component hover even when it shoved to user that the cursor is not yet on top of the object. Now when using clickableBorder, the children elements scss must include this code: pointer-events: all; Otherwise the object won't be clickable.
---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected. Yes
- **JSDoc**: I have added or updated JSDoc comments for all relevant code. Yes
- **Debugging**: No `console.log()` or other debugging statements are left. Yes
- **Clean Code**: Removed commented-out or unnecessary code. Yes
- **Tests**: Added new tests or updated existing ones for the changes made. No
- **Documentation**: Documentation has been updated (if applicable). Yes

---

## 📝 **Additional Information**

The green area shows the padding that was clickable even though it was invisible to user.
![Screenshot 2024-10-22 142734](https://github.com/user-attachments/assets/9e95ee54-8f3f-438f-bfab-684a922d2d09)