### PR TITLE
aku/bug/#80-fix-clickableBorder

### DIFF
--- a/frontend-next-migration/src/entities/Hero/ui/HeroCard/HeroCard.module.scss
+++ b/frontend-next-migration/src/entities/Hero/ui/HeroCard/HeroCard.module.scss
@@ -23,6 +23,9 @@
 
 
 .ClickableBorder {
+  display: flex;
+  justify-content: center;
+  align-items: center;
   width: 100%;
   height: 100%;
 
@@ -30,9 +33,9 @@
 
 
   //--paddingMultiplier: 0.07;
-  --paddingMultiplier: 0.1;
-  --padding: calc(var(--paddingMultiplier) * var(--cardWidthLocal));
-  padding: var(--padding) var(--padding) var(--padding); // works fine with border 3
+  //--paddingMultiplier: 0.1;
+  //--padding: calc(var(--paddingMultiplier) * var(--cardWidthLocal));
+  //padding: var(--padding) var(--padding) var(--padding); // works fine with border 3
   //padding: var(--padding) var(--padding) calc(var(--padding) * 2); // works fine with border-border2 images
 
   &:hover,
@@ -46,8 +49,8 @@
 .HeroDiv {
   pointer-events: all;
   cursor: pointer;
-  width: 100%;
-  height: 100%;
+  width: 80%;
+  height: 80%;
   border-radius: var(--border-radius-custom);
   border: var(--border-thick-black);
 

--- a/frontend-next-migration/src/shared/ui/ClickableBorder/ClickableBorder.module.scss
+++ b/frontend-next-migration/src/shared/ui/ClickableBorder/ClickableBorder.module.scss
@@ -1,5 +1,5 @@
 .content {
-  border-image-slice: 0.01 fill;
+  border-image-slice: 5 fill;
   border-image-repeat: stretch;
   display: block;
   pointer-events:none;  


### PR DESCRIPTION
## 📄 **Pull Request Overview**

**Issue Number**: #80 

## 🔧 **Changes Made**

Removed padding from clickableBorder. It still needs space for the border image, so I reduced the size of the HeroDiv and centered it within the container using flexbox.

I'm not sure if I understood the issue correct but now the component doesn't have a padding.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected. 
- **JSDoc**: I have added or updated JSDoc comments for all relevant code. 
- **Debugging**: No `console.log()` or other debugging statements are left. 
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**