### PR TITLE
sakari/enc/276-enhancement-request-ensure-parentalauth…

### DIFF
--- a/frontend-next-migration/src/entities/Auth/types/authUser.d.ts
+++ b/frontend-next-migration/src/entities/Auth/types/authUser.d.ts
@@ -3,7 +3,7 @@ import { IProfile } from '@/entities/Profile';
 
 export type IPlayerRegisterPartDto = Pick<
     IPlayer,
-    'name' | 'backpackCapacity' | 'uniqueIdentifier' | 'above13'
+    'name' | 'backpackCapacity' | 'uniqueIdentifier' | 'above13' | 'parentalAuth'
 >;
 
 export type IUserRegisterDto = Pick<IProfile<IPlayer>, 'username'> & {

--- a/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.test.ts
+++ b/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.test.ts
@@ -83,6 +83,7 @@ describe('useRegisterForm', () => {
                 backpackCapacity: 100,
                 name: 'testuser',
                 above13: true,
+                parentalAuth: false,
             },
         };
 

--- a/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
+++ b/frontend-next-migration/src/features/AuthByUsername/model/useRegisterForm.ts
@@ -37,6 +37,7 @@ export const useRegisterForm = (toLoginPage: string) => {
                 backpackCapacity: 100,
                 name: fieldValues.username,
                 above13: fieldValues.ageConsent,
+                parentalAuth: false,
             },
         };
         await regist(ObjectToBeSent);


### PR DESCRIPTION
## 📄 **Pull Request Overview**

**Issue Number**: #276 

Our registration form is not setting the parentalAuth field explicitly. As a result, the API assigns it a NULL value by default. (Probably since 1.11.2024 API update) This oversight is causing significant 403 Forbidden authorization issues, preventing users from doing basicly anything and leaving them without a way to resolve the issue on their end.

## 🔧 **Changes Made**

1. Added `parentalAuth` field to `useRegisterForm.ts`

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

ParentalAuth is now always set false upon registeration. `above13 = true` required upon registration so `parentalAuth` is expected to be false.
![image](https://github.com/user-attachments/assets/d6589603-48bc-4e97-a465-a51c128106ec)

A better solution would be to make above13 optional, not required form checkbox and then parentalAuth should be given a possibility to be set in Profile page etc... (consent)

