### PR TITLE
Pauliina/enhancement/211 make a custom select menu

### DIFF
--- a/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.test.tsx
+++ b/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.test.tsx
@@ -25,20 +25,31 @@ describe('LangSwitcher', () => {
     it('renders with the correct default language', () => {
         render(<LangSwitcher />);
 
-        const select = screen.getByTestId('language-switcher') as HTMLSelectElement; // Cast to HTMLSelectElement
-        expect(select).toHaveValue('en'); // Check that the default language is 'en'
+        const button = screen.getByRole('button', { name: /finnish|english/i }); // Look for the button with the current language label
+        expect(button).toBeInTheDocument(); // Ensure the button is present
+
+        // Verify that the button's text corresponds to the default language ('en')
+        expect(button).toHaveTextContent('english');
     });
 
     it('changes the language when a new option is selected', () => {
         // Mock window.location.href to prevent real navigation
-        // @ts-ignore
-        delete window.location;
-        window.location = { href: '' } as Location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '',
+            },
+            writable: true,
+        });
 
         render(<LangSwitcher />);
 
-        const select = screen.getByTestId('language-switcher') as HTMLSelectElement; // Cast to HTMLSelectElement
-        fireEvent.change(select, { target: { value: 'fi' } });
+        // Find the button that toggles the dropdown
+        const button = screen.getByRole('button', { name: /finnish|english/i });
+        fireEvent.click(button);
+
+        // Find the list item for the Finnish option and click it
+        const finnishOption = screen.getByRole('option', { name: /finnish/i });
+        fireEvent.click(finnishOption);
 
         // Check that the URL is updated with the new language
         expect(window.location.href).toBe('/fi/some-path');
@@ -46,14 +57,22 @@ describe('LangSwitcher', () => {
 
     it('does not change the URL if the same language is selected', () => {
         // Mock window.location.href to prevent real navigation
-        // @ts-ignore
-        delete window.location;
-        window.location = { href: '/en/some-path' } as Location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '/en/some-path',
+            },
+            writable: true,
+        });
 
         render(<LangSwitcher />);
 
-        const select = screen.getByTestId('language-switcher') as HTMLSelectElement; // Cast to HTMLSelectElement
-        fireEvent.change(select, { target: { value: 'en' } });
+        // Find the button that toggles the dropdown
+        const button = screen.getByRole('button', { name: /finnish|english/i });
+        fireEvent.click(button);
+
+        // Find the list item for the English option and click it
+        const finnishOption = screen.getByRole('option', { name: /english/i });
+        fireEvent.click(finnishOption);
 
         // Check that the URL remains unchanged
         expect(window.location.href).toBe('/en/some-path');
@@ -68,16 +87,24 @@ describe('LangSwitcher', () => {
 
     it('calls handleChangeLanguage when selecting a different language', () => {
         // Mock window.location.href to prevent real navigation
-        // @ts-ignore
-        delete window.location;
-        window.location = { href: '' } as Location;
+        Object.defineProperty(window, 'location', {
+            value: {
+                href: '',
+            },
+            writable: true,
+        });
 
         render(<LangSwitcher />);
 
-        const select = screen.getByTestId('language-switcher') as HTMLSelectElement; // Cast to HTMLSelectElement
-        fireEvent.change(select, { target: { value: 'fi' } });
+        // Find the button that toggles the dropdown
+        const button = screen.getByRole('button', { name: /finnish|english/i });
+        fireEvent.click(button);
 
-        // Expect window.location.href to be updated
+        // Find the list item for the Finnish option and click it
+        const finnishOption = screen.getByRole('option', { name: /finnish/i });
+        fireEvent.click(finnishOption);
+
+        // Check that the URL is updated with the new language
         expect(window.location.href).toBe('/fi/some-path');
     });
 
@@ -89,19 +116,31 @@ describe('LangSwitcher', () => {
 
         render(<LangSwitcher />);
 
-        const select = screen.getByTestId('language-switcher') as HTMLSelectElement; // Cast to HTMLSelectElement
-        expect(select).not.toHaveValue('es'); // 'es' should not be available
-        expect(select).toHaveValue('fi'); // Fallback to 'en'
+        // Find the button that shows the current language
+        const button = screen.getByRole('button', { name: /finnish|english/i });
+
+        // Assert that the fallback language is displayed
+        expect(button).toHaveTextContent('finnish');
+
+        // Assert that the unavailable language is not displayed
+        expect(button).not.toHaveTextContent('es');
     });
 
     it('contains all available language options', () => {
         render(<LangSwitcher />);
 
+        // Open the dropdown to reveal the options
+        const button = screen.getByRole('button', { name: /finnish|english/i });
+        fireEvent.click(button);
+
+        // Get all options rendered as list items
         const options = screen.getAllByRole('option');
         const availableLanguages = ['fi', 'en'];
+
+        // Verify each option's value is in the list of available languages
         options.forEach((option) => {
-            // @ts-ignore
-            expect(availableLanguages).toContain(option.value); // Check that all options are valid
+            const value = option.getAttribute('data-option-value');
+            expect(availableLanguages).toContain(value);
         });
     });
 });

--- a/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
+++ b/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
@@ -19,7 +19,6 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
     const [isOpen, setIsOpen] = useState<boolean>(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
 
-    // const { t, i18n: { changeLanguage, language: currentLocale } } = useClientTranslation();
     const {
         t,
         i18n: { language },
@@ -33,22 +32,13 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
 
     const handleChangeLanguage = (newLanguage: AppLanguage) => {
         window.location.href = currentPathname.replace(`/${language}`, `/${newLanguage}`);
-
-        // router.push(currentPathname.replace(`/${language}`, `/${newLanguage}`));
-
-        // setTimeout(()=>{
-        //     window.location.reload();
-        // },400)
     };
 
-    // router.refresh();
-    // window.location.reload();\
-
-    // window.reload();
     const handleOptionClick = (option: Option) => {
         const selectedLanguage = option.value as AppLanguage;
         handleChangeLanguage(selectedLanguage);
         setIsOpen(false);
+        setSelected(option.label);
     };
 
     const toggleDropdown = () => setIsOpen(!isOpen);
@@ -72,6 +62,11 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
         }
     };
 
+    // Get the label of the current language
+    const [selected, setSelected] = useState<string>(
+        options.find((option) => option.value === language)?.label || '',
+    );
+
     // Close the menu if clicking outside of it
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
@@ -87,6 +82,7 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
 
     return (
         <div
+            data-testid="language-switcher"
             ref={dropdownRef}
             className={classNames('', {}, [className])}
         >
@@ -96,7 +92,7 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
                 aria-expanded={isOpen}
             >
                 {/*Add more languages here*/}
-                {language === 'fi' ? t('finnish') : language === 'en' && t('english')}
+                {selected}
                 <FontAwesomeIcon icon={faChevronDown} />
             </button>
             {isOpen && (

--- a/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
+++ b/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
@@ -1,20 +1,35 @@
 import { usePathname } from 'next/navigation';
-import { ChangeEvent } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { classNames } from '@/shared/lib/classNames/classNames';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 type LangSwitcherProps = {
     className?: string;
 };
 
+type Option = {
+    label: string;
+    value: string;
+};
+
 export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
     const currentPathname = usePathname();
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
 
     // const { t, i18n: { changeLanguage, language: currentLocale } } = useClientTranslation();
     const {
         t,
         i18n: { language },
     } = useTranslation();
+
+    const options = [
+        { label: t('finnish'), value: 'fi' },
+        { label: t('english'), value: 'en' },
+        // Add more languages here
+    ];
 
     const handleChangeLanguage = (newLanguage: AppLanguage) => {
         window.location.href = currentPathname.replace(`/${language}`, `/${newLanguage}`);
@@ -30,21 +45,80 @@ export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
     // window.location.reload();\
 
     // window.reload();
-    const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const selectedLanguage = event.target.value as AppLanguage;
+    const handleOptionClick = (option: Option) => {
+        const selectedLanguage = option.value as AppLanguage;
         handleChangeLanguage(selectedLanguage);
+        setIsOpen(false);
     };
 
+    const toggleDropdown = () => setIsOpen(!isOpen);
+
+    // Selecting an option by pressing enter (for keyboard accessibility)
+    const handleEnter = (event: React.KeyboardEvent<HTMLLIElement>) => {
+        const items = Array.from(document.querySelectorAll('.selectable-item'));
+        const activeElement = document.activeElement;
+        // Active element is one of the options and the pressed key is enter
+        if (activeElement && event.key === 'Enter') {
+            const currentIndex = items.indexOf(activeElement);
+            if (currentIndex !== -1) {
+                const selectedItem = items[currentIndex];
+                const value = selectedItem.getAttribute('data-option-value');
+                const name = selectedItem.getAttribute('data-name');
+                if (value && name) {
+                    const option: Option = { label: name, value: value };
+                    handleOptionClick(option);
+                }
+            }
+        }
+    };
+
+    // Close the menu if clicking outside of it
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, []);
+
     return (
-        <select
-            data-testid="language-switcher"
-            value={language}
-            onChange={handleSelectChange}
+        <div
+            ref={dropdownRef}
             className={classNames('', {}, [className])}
         >
-            <option value="fi"> {t('finnish')}</option>
-            <option value="en">{t('english')}</option>
-            {/*<option value="ru">{t('russian')}</option>*/}
-        </select>
+            <button
+                onClick={toggleDropdown}
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+            >
+                {/*Add more languages here*/}
+                {language === 'fi' ? t('finnish') : language === 'en' && t('english')}
+                <FontAwesomeIcon icon={faChevronDown} />
+            </button>
+            {isOpen && (
+                <ul>
+                    {options.map((option) => (
+                        <li
+                            className="selectable-item"
+                            key={option.value}
+                            onClick={() => handleOptionClick(option)}
+                            // For screen readers
+                            role="option"
+                            aria-selected={option.value === language ? 'true' : 'false'}
+                            tabIndex={0}
+                            data-option-value={option.value}
+                            data-name={option.label}
+                            onKeyDown={handleEnter}
+                        >
+                            {option.label}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
     );
 };

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
@@ -112,11 +112,46 @@
 
 
 .langSwitcher {
-  border-radius: var(--border-radius-custom);
-  outline: 2px solid var(--inverted-primary-color);
-  background-color: rgba(0, 0, 0, 0.8);
-  color: var(--secondary-color) !important;
-  font-size: var(--font-size-m) !important;
+  position: relative;
+
+  button {
+    background-color: rgba(0, 0, 0, 0.8);
+    font-size: var(--font-size-m) !important;
+    color: var(--secondary-color) !important;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    border: 2px solid transparent;
+    cursor: pointer;
+  }
+
+  button:focus {
+    outline: 2px solid white;
+  }
+
+  ul {
+    position: absolute;
+    margin-top: 5px;
+    left: 0;
+    right: 0;
+    height: max-content;
+    width: max-content;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    list-style-type: none;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  li {
+    cursor: pointer;
+  }
+
+  li:hover {
+    color: var(--secondary-color);
+  }
 }
 
 .authButton {

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
@@ -143,6 +143,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
+    background-color: var(--transparent-bg-dark);
   }
 
   li {

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
@@ -98,15 +98,47 @@
 }
 
 .langSwitcher {
-  border-radius: var(--border-radius-custom);
-  border: 2px solid var(--inverted-primary-color);
-  &:focus {
-    outline: none;
-    box-shadow: none;
-  }
-  background-color: rgba(0, 0, 0, 0.8);
-  color: var(--secondary-color) !important;
+  position: relative;
   font-size: var(--font-size-m) !important;
+
+  button {
+    background-color: rgba(0, 0, 0, 0.8);
+    font-size: var(--font-size-m) !important;
+    color: var(--secondary-color) !important;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    border: 2px solid transparent;
+    cursor: pointer;
+  }
+
+  button:focus {
+    outline: 2px solid white;
+  }
+
+  ul {
+    position: absolute;
+    margin-top: 5px;
+    top: -110px;
+    height: max-content;
+    width: max-content;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    list-style-type: none;
+    padding: 0 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: flex-start;
+  }
+
+  li {
+    cursor: pointer;
+  }
+
+
+  li:hover {
+    color: var(--secondary-color);
+  }
 }
 
 

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
@@ -129,6 +129,7 @@
     flex-direction: column;
     align-items: center;
     justify-content: flex-start;
+    background-color: var(--transparent-bg-dark);
   }
 
   li {


### PR DESCRIPTION
## 📄 **Pull Request Overview**

**Issue Number**: 211

## 🔧 **Changes Made**

1. I made a custom select menu for the LangSwitcher menu. I attempted to follow the style of the other navbar elements.
2. It also works on mobile.
3. I also made it work with keyboards for accessibility.
4. I updated the tests.

---

## 📝 **Additional Information**

<img width="942" alt="desktop2" src="https://github.com/user-attachments/assets/1b383ad3-6751-4984-8c64-8107e3af1bcd">

<img width="941" alt="desktop" src="https://github.com/user-attachments/assets/cf79ea73-0553-4a35-b2e4-40eb2957ffe0">

<img width="684" alt="mobile" src="https://github.com/user-attachments/assets/9474f439-9942-4fdd-bccd-04d55bb3ceb8">

Problem: the test "falls back to default language when current language is not in options" fails. If the user types for example altzone.fi/es, it does switch to a supported language, but the incorrect language tag stays in the url, e.g. altzone.fi/en/es, causing the error page to be displayed.