### PR TITLE
Custom select menu for LangSwitcher

### DIFF
--- a/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
+++ b/frontend-next-migration/src/features/LangSwitcher/ui/LangSwitcher.tsx
@@ -1,50 +1,122 @@
 import { usePathname } from 'next/navigation';
-import { ChangeEvent } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { classNames } from '@/shared/lib/classNames/classNames';
+import { faChevronDown } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 type LangSwitcherProps = {
     className?: string;
 };
 
+type Option = {
+    label: string;
+    value: string;
+};
+
 export const LangSwitcher = ({ className = '' }: LangSwitcherProps) => {
     const currentPathname = usePathname();
+    const [isOpen, setIsOpen] = useState<boolean>(false);
+    const dropdownRef = useRef<HTMLDivElement>(null);
 
-    // const { t, i18n: { changeLanguage, language: currentLocale } } = useClientTranslation();
     const {
         t,
         i18n: { language },
     } = useTranslation();
 
+    const options = [
+        { label: t('finnish'), value: 'fi' },
+        { label: t('english'), value: 'en' },
+        // Add more languages here
+    ];
+
+    // Get the label of the current language
+    const [selected, setSelected] = useState<string>(
+        options.find((option) => option.value === language)?.label || options[0]?.label || '',
+    );
+
     const handleChangeLanguage = (newLanguage: AppLanguage) => {
         window.location.href = currentPathname.replace(`/${language}`, `/${newLanguage}`);
-
-        // router.push(currentPathname.replace(`/${language}`, `/${newLanguage}`));
-
-        // setTimeout(()=>{
-        //     window.location.reload();
-        // },400)
     };
 
-    // router.refresh();
-    // window.location.reload();\
-
-    // window.reload();
-    const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
-        const selectedLanguage = event.target.value as AppLanguage;
+    const handleOptionClick = (option: Option) => {
+        const selectedLanguage = option.value as AppLanguage;
         handleChangeLanguage(selectedLanguage);
+        setIsOpen(false);
+        setSelected(option.label);
     };
+
+    const toggleDropdown = () => setIsOpen(!isOpen);
+
+    // Selecting an option by pressing enter (for keyboard accessibility)
+    const handleEnter = (event: React.KeyboardEvent<HTMLLIElement>) => {
+        const items = Array.from(document.querySelectorAll('.selectable-item'));
+        const activeElement = document.activeElement;
+        // Active element is one of the options and the pressed key is enter
+        if (activeElement && event.key === 'Enter') {
+            const currentIndex = items.indexOf(activeElement);
+            if (currentIndex !== -1) {
+                const selectedItem = items[currentIndex];
+                const value = selectedItem.getAttribute('data-option-value');
+                const name = selectedItem.getAttribute('data-name');
+                if (value && name) {
+                    const option: Option = { label: name, value: value };
+                    handleOptionClick(option);
+                }
+            }
+        }
+    };
+
+    // Close the menu if clicking outside of it
+    useEffect(() => {
+        const handleClickOutside = (event: MouseEvent) => {
+            if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+                setIsOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleClickOutside);
+        return () => {
+            document.removeEventListener('mousedown', handleClickOutside);
+        };
+    }, []);
 
     return (
-        <select
+        <div
             data-testid="language-switcher"
-            value={language}
-            onChange={handleSelectChange}
+            ref={dropdownRef}
             className={classNames('', {}, [className])}
         >
-            <option value="fi"> {t('finnish')}</option>
-            <option value="en">{t('english')}</option>
-            {/*<option value="ru">{t('russian')}</option>*/}
-        </select>
+            <button
+                onClick={toggleDropdown}
+                aria-haspopup="true"
+                aria-expanded={isOpen}
+            >
+                {selected}
+                <FontAwesomeIcon
+                    icon={faChevronDown}
+                    size="2xs"
+                />
+            </button>
+            {isOpen && (
+                <ul>
+                    {options.map((option) => (
+                        <li
+                            className="selectable-item"
+                            key={option.value}
+                            onClick={() => handleOptionClick(option)}
+                            // For screen readers
+                            role="option"
+                            aria-selected={option.value === language ? 'true' : 'false'}
+                            tabIndex={0}
+                            data-option-value={option.value}
+                            data-name={option.label}
+                            onKeyDown={handleEnter}
+                        >
+                            {option.label}
+                        </li>
+                    ))}
+                </ul>
+            )}
+        </div>
     );
 };

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
@@ -124,14 +124,50 @@
 
 
 .langSwitcher {
+  position: relative;
   border-radius: var(--border-radius-custom);
   border: 2px solid var(--inverted-primary-color);
   background-color: rgba(0, 0, 0, 0.8);
   color: var(--secondary-color) !important;
   font-size: var(--font-size-m) !important;
-  //text-align: center;
   padding: 2px;
- }
+
+  button {
+    background-color: rgba(0, 0, 0, 0.8);
+    font-size: var(--font-size-m) !important;
+    color: var(--secondary-color) !important;
+    border-radius: var(--border-radius-custom);
+    border: 2px solid transparent;
+    cursor: pointer;
+    min-width: 80px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  ul {
+    position: absolute;
+    margin-top: 5px;
+    left: 0;
+    right: 0;
+    height: max-content;
+    width: max-content;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    list-style-type: none;
+    padding: 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    background-color: var(--transparent-bg-dark);
+  }
+
+  li {
+    cursor: pointer;
+  }
+
+}
 
 .authButton {
   border-radius: var(--border-radius-custom);

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarDesktop/NavbarDesktop.module.scss
@@ -151,11 +151,11 @@
     left: 0;
     right: 0;
     height: max-content;
-    width: max-content;
+    width: 100%;
     border-radius: var(--border-radius-custom);
     outline: 2px solid var(--inverted-primary-color);
     list-style-type: none;
-    padding: 10px;
+    padding: 4px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -165,6 +165,13 @@
 
   li {
     cursor: pointer;
+    height: 25px;
+    display:flex;
+    align-items: center;
+  }
+
+  li:hover {
+    color: white;
   }
 
 }

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
@@ -123,14 +123,12 @@
 
   ul {
     position: absolute;
-    margin-top: 5px;
-    top: -105px;
-    height: max-content;
-    width: max-content;
+    top: -60px;
+    width: 100%;
     border-radius: var(--border-radius-custom);
     outline: 2px solid var(--inverted-primary-color);
     list-style-type: none;
-    padding: 0 10px;
+    padding: 4px;
     display: flex;
     flex-direction: column;
     align-items: flex-start;
@@ -140,6 +138,13 @@
 
   li {
     cursor: pointer;
+    height: 25px;
+    display:flex;
+    align-items: center;
+  }
+
+  li:hover {
+    color: white;
   }
 
 }

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobile/NavbarMobile.module.scss
@@ -98,15 +98,50 @@
 }
 
 .langSwitcher {
+  position: relative;
   border-radius: var(--border-radius-custom);
   border: 2px solid var(--inverted-primary-color);
-  &:focus {
-    outline: none;
-    box-shadow: none;
-  }
   background-color: rgba(0, 0, 0, 0.8);
   color: var(--secondary-color) !important;
   font-size: var(--font-size-m) !important;
+  height: 42px;
+
+  button {
+    padding: 2px;
+    background-color: rgba(0, 0, 0, 0.8);
+    font-size: var(--font-size-m) !important;
+    color: var(--secondary-color) !important;
+    border-radius: var(--border-radius-custom);
+    border: 2px solid transparent;
+    cursor: pointer;
+    min-width: 80px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+
+  ul {
+    position: absolute;
+    margin-top: 5px;
+    top: -105px;
+    height: max-content;
+    width: max-content;
+    border-radius: var(--border-radius-custom);
+    outline: 2px solid var(--inverted-primary-color);
+    list-style-type: none;
+    padding: 0 10px;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    justify-content: flex-start;
+    background-color: var(--transparent-bg-dark);
+  }
+
+  li {
+    cursor: pointer;
+  }
+
 }
 
 


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes 211

## 🔧 **Changes Made**

1. Made a custom drop-down select menu for switching languages.

2. Added the requested style improvements: aligned the text to left, made the arrow smaller with more spacing, improved the border's style cohesion, and made the mobile version look cleaner.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

<img width="576" alt="custom-menu" src="https://github.com/user-attachments/assets/b7890925-1d58-4d3f-ace7-3850c21f112b">

