### PR TITLE
Jarno/enhancement/131-team-page-enhancement-3

### DIFF
--- a/frontend-next-migration/src/entities/Member/ui/MemberItem.module.scss
+++ b/frontend-next-migration/src/entities/Member/ui/MemberItem.module.scss
@@ -52,7 +52,6 @@
     border-radius: 50%;
     overflow: hidden;
     transition: transform 0.3s ease-in-out;
-    //@include link-scale-effect('icon');
   }
 
   .memberLogoEnlarged {

--- a/frontend-next-migration/src/entities/Member/ui/MemberItem.module.scss
+++ b/frontend-next-migration/src/entities/Member/ui/MemberItem.module.scss
@@ -14,9 +14,13 @@
   }
 
   .taskText {
+    font-weight: lighter;
+    font-size: 80%;
     text-align: left;
     flex: 2;
     min-width: 0;
+    display: flex;
+    align-items: center;
   }
 
   .iconContainer {
@@ -26,6 +30,9 @@
     justify-content: flex-end;
     flex: 1;
     min-width: 0;
+    @media only screen and (min-width: 760px) {
+      padding-right: 2rem;
+    }
   }
 
   .centerContainer {
@@ -44,7 +51,13 @@
     height: clamp(0.5rem, 3vw, 2rem);
     border-radius: 50%;
     overflow: hidden;
-    @include link-scale-effect('icon');
+    transition: transform 0.3s ease-in-out;
+    //@include link-scale-effect('icon');
+  }
+
+  .memberLogoEnlarged {
+    transform: scale(3);
+    transition: transform 0.3s ease-in-out;
   }
 
   .Logo {

--- a/frontend-next-migration/src/entities/Member/ui/MemberItem.tsx
+++ b/frontend-next-migration/src/entities/Member/ui/MemberItem.tsx
@@ -20,7 +20,7 @@ const MemberItem: FC<MemberItemProps> = ({ member, language }) => {
      * @type {boolean}
      * @default false
      */
-    const [isEnlarged, setIsEnlarged] = useState(false);
+    const [isEnlarged, setIsEnlarged] = useState<boolean>(false);
     /**
      * Handles image clicking. Changes the state of the image.
      */

--- a/frontend-next-migration/src/entities/Member/ui/MemberItem.tsx
+++ b/frontend-next-migration/src/entities/Member/ui/MemberItem.tsx
@@ -1,7 +1,7 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import Image from 'next/image';
 import Link from 'next/link';
-import { FC } from 'react';
+import { FC, useState } from 'react';
 import { getLinks } from '../api/mappers';
 import { Member } from '../model/types/types';
 import cls from './MemberItem.module.scss';
@@ -14,6 +14,20 @@ interface MemberItemProps {
 }
 
 const MemberItem: FC<MemberItemProps> = ({ member, language }) => {
+    /**
+     * Manage the enlarged mode of the image.
+     * @description When the boolean value is true, image is enlarged.
+     * @type {boolean}
+     * @default false
+     */
+    const [isEnlarged, setIsEnlarged] = useState(false);
+    /**
+     * Handles image clicking. Changes the state of the image.
+     */
+    const handleClick = () => {
+        setIsEnlarged(!isEnlarged);
+    };
+
     const linksMap = getLinks();
 
     const logoUrl =
@@ -31,12 +45,15 @@ const MemberItem: FC<MemberItemProps> = ({ member, language }) => {
                     <span className={cls.memberName}>{member.name}</span>
                     <span className={cls.taskText}>{task}</span>
                     <div className={cls.iconContainer}>
-                        <div className={cls.memberLogo}>
+                        <div
+                            className={`${cls.memberLogo} ${isEnlarged ? cls.memberLogoEnlarged : ''}`}
+                        >
                             {logoUrl ? (
                                 <Image
                                     src={logoUrl}
                                     alt={member.name}
                                     className={cls.Logo}
+                                    onClick={handleClick}
                                     width={500}
                                     height={500}
                                 />


### PR DESCRIPTION
Team member logos will enlarge when clicked and return to their original size when clicked again.
Added media query for smaller screens (padding) to avoid the enlarged logo going partially off screen.
The text in the member task section has been made slightly smaller for better visibility.

closes 131

## 🔧 **Changes Made**

1. [Briefly describe changes you made]
Added useState for click handling and added css rules for text and logo

2. [Any refactoring or clean-up tasks]

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: [Include any screenshots or videos if the changes affect the UI]

https://github.com/user-attachments/assets/46078366-111a-4ef5-b455-d861dc6d1cf7


https://github.com/user-attachments/assets/5959983b-e8f1-4c12-9487-0e3265d83046


- **Known Issues**: [List any known issues or limitations]
Implementing Directus changed the page layout for some reason. So it may be necessary to make a new issue for adjusting the text spacing vertically to clarify the content on the page. Not included in this issue and may require larger changes elsewhere in the code.
