### PR TITLE
Kaisa/bug/318 update gallery url when language is changed

### DIFF
--- a/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.test.ts
+++ b/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.test.ts
@@ -18,6 +18,12 @@ jest.mock('../api/translations', () => ({
     getCategoryTranslation: jest.fn(),
 }));
 
+jest.mock('@/shared/const/envHelper', () => ({
+    envHelper: {
+        directusHost: 'https://strapi.altzone.fi',
+    },
+}));
+
 describe('useGetDirectusGalleryImages', () => {
     const mockLanguage = 'en';
 
@@ -51,86 +57,86 @@ describe('useGetDirectusGalleryImages', () => {
         expect(result.current.error).toBeNull();
     });
 
-    // it('transforms data correctly', () => {
-    //     const mockCategories = [
-    //         { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
-    //     ];
-    //     const mockPhotoVersions = [
-    //         {
-    //             id: '1',
-    //             image: 'image1.jpg',
-    //             width: 100,
-    //             height: 100,
-    //             translations: [{ language: 'en', altText: 'Alt 1' }],
-    //         },
-    //     ];
-    //     const mockPhotoObjects = [
-    //         {
-    //             id: '1',
-    //             category: { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
-    //             preview: {
-    //                 id: '2',
-    //                 image: 'preview1.jpg',
-    //                 width: 50,
-    //                 height: 50,
-    //                 translations: [],
-    //             },
-    //             full: { id: '3', image: 'full1.jpg', width: 100, height: 100, translations: [] },
-    //         },
-    //     ];
-    //
-    //     (useGetPhotoObjectsQuery as jest.Mock).mockReturnValue({
-    //         data: mockPhotoObjects,
-    //         isLoading: false,
-    //         error: null,
-    //     });
-    //     (useGetPhotoVersionsQuery as jest.Mock).mockReturnValue({
-    //         data: mockPhotoVersions,
-    //         isLoading: false,
-    //         error: null,
-    //     });
-    //     (useGetGalleryCategoriesQuery as jest.Mock).mockReturnValue({
-    //         data: mockCategories,
-    //         isLoading: false,
-    //         error: null,
-    //     });
-    //
-    //     (getPhotoVersionTranslation as jest.Mock).mockImplementation(
-    //         (translations) => translations[0]?.altText || '',
-    //     );
-    //     (getCategoryTranslation as jest.Mock).mockImplementation(
-    //         (translations) => translations[0]?.name || '',
-    //     );
-    //
-    //     const { result } = renderHook(() => useGetDirectusGalleryImages(mockLanguage));
-    //
-    //     expect(result.current.categories).toEqual([{ id: '1', name: 'Category 1' }]);
-    //     expect(result.current.photoVersions).toEqual([
-    //         { id: '1', image: 'image1.jpg', width: 100, height: 100, altText: 'Alt 1' },
-    //     ]);
-    //     expect(result.current.photoObjects).toEqual([
-    //         {
-    //             id: '1',
-    //             category: { id: '1', name: 'Category 1' },
-    //             versions: {
-    //                 preview: {
-    //                     id: '2',
-    //                     image: 'https://strapi.altzone.fi/assets/preview1.jpg',
-    //                     width: 50,
-    //                     height: 50,
-    //                     altText: '',
-    //                 },
-    //                 full: {
-    //                     id: '3',
-    //                     image: 'https://strapi.altzone.fi/assets/full1.jpg',
-    //                     width: 100,
-    //                     height: 100,
-    //                     altText: '',
-    //                 },
-    //             },
-    //         },
-    //     ]);
-    // });
+    it('transforms data correctly', () => {
+        const mockCategories = [
+            { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
+        ];
+        const mockPhotoVersions = [
+            {
+                id: '1',
+                image: 'image1.jpg',
+                width: 100,
+                height: 100,
+                translations: [{ language: 'en', altText: 'Alt 1' }],
+            },
+        ];
+        const mockPhotoObjects = [
+            {
+                id: '1',
+                category: { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
+                preview: {
+                    id: '2',
+                    image: 'preview1.jpg',
+                    width: 50,
+                    height: 50,
+                    translations: [],
+                },
+                full: { id: '3', image: 'full1.jpg', width: 100, height: 100, translations: [] },
+            },
+        ];
+
+        (useGetPhotoObjectsQuery as jest.Mock).mockReturnValue({
+            data: mockPhotoObjects,
+            isLoading: false,
+            error: null,
+        });
+        (useGetPhotoVersionsQuery as jest.Mock).mockReturnValue({
+            data: mockPhotoVersions,
+            isLoading: false,
+            error: null,
+        });
+        (useGetGalleryCategoriesQuery as jest.Mock).mockReturnValue({
+            data: mockCategories,
+            isLoading: false,
+            error: null,
+        });
+
+        (getPhotoVersionTranslation as jest.Mock).mockImplementation(
+            (translations) => translations[0]?.altText || '',
+        );
+        (getCategoryTranslation as jest.Mock).mockImplementation(
+            (translations) => translations[0]?.name || '',
+        );
+
+        const { result } = renderHook(() => useGetDirectusGalleryImages(mockLanguage));
+
+        expect(result.current.categories).toEqual([{ id: '1', name: 'Category 1' }]);
+        expect(result.current.photoVersions).toEqual([
+            { id: '1', image: 'image1.jpg', width: 100, height: 100, altText: 'Alt 1' },
+        ]);
+        expect(result.current.photoObjects).toEqual([
+            {
+                id: '1',
+                category: { id: '1', name: 'Category 1' },
+                versions: {
+                    preview: {
+                        id: '2',
+                        image: 'https://strapi.altzone.fi/assets/preview1.jpg',
+                        width: 50,
+                        height: 50,
+                        altText: '',
+                    },
+                    full: {
+                        id: '3',
+                        image: 'https://strapi.altzone.fi/assets/full1.jpg',
+                        width: 100,
+                        height: 100,
+                        altText: '',
+                    },
+                },
+            },
+        ]);
+    });
 
     it('handles loading states', () => {
         (useGetPhotoObjectsQuery as jest.Mock).mockReturnValue({

--- a/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.test.ts
+++ b/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.test.ts
@@ -110,14 +110,16 @@ describe('useGetDirectusGalleryImages', () => {
 
         const { result } = renderHook(() => useGetDirectusGalleryImages(mockLanguage));
 
-        expect(result.current.categories).toEqual([{ id: '1', name: 'Category 1' }]);
+        expect(result.current.categories).toEqual([
+            { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
+        ]);
         expect(result.current.photoVersions).toEqual([
             { id: '1', image: 'image1.jpg', width: 100, height: 100, altText: 'Alt 1' },
         ]);
         expect(result.current.photoObjects).toEqual([
             {
                 id: '1',
-                category: { id: '1', name: 'Category 1' },
+                category: { id: '1', translations: [{ language: 'en', name: 'Category 1' }] },
                 versions: {
                     preview: {
                         id: '2',

--- a/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.ts
+++ b/frontend-next-migration/src/entities/Gallery/api/useGetDirectusGalleryImages.ts
@@ -1,7 +1,7 @@
 import { envHelper } from '@/shared/const/envHelper';
 import { useMemo } from 'react';
 import { Category, PhotoObject, PhotoVersion } from '../types/gallery';
-import { getPhotoVersionTranslation, getCategoryTranslation } from '../api/translations';
+import { getPhotoVersionTranslation } from '../api/translations';
 import { useGetGalleryCategoriesQuery } from '../api/galleryCategoriesApi';
 import { useGetPhotoObjectsQuery, useGetPhotoVersionsQuery } from '../api/galleryApi';
 
@@ -49,7 +49,7 @@ export const useGetDirectusGalleryImages = (lng: string) => {
         if (!cData) return [];
         return cData.map((item) => ({
             id: item.id,
-            name: getCategoryTranslation(item.translations || [], lng),
+            translations: item.translations,
         }));
     }, [cData]);
 
@@ -70,7 +70,7 @@ export const useGetDirectusGalleryImages = (lng: string) => {
             id: item.id,
             category: {
                 id: item.category.id,
-                name: getCategoryTranslation(item.category.translations || [], lng),
+                translations: item.category.translations,
             },
             versions: {
                 preview: {

--- a/frontend-next-migration/src/entities/Gallery/types/gallery.d.ts
+++ b/frontend-next-migration/src/entities/Gallery/types/gallery.d.ts
@@ -31,7 +31,7 @@ export interface PhotoVersionTranslations {
 
 export interface Category {
     id: string;
-    name: string;
+    translations: CategoryTranslations[];
 }
 
 export interface PhotoVersion {

--- a/frontend-next-migration/src/features/NavigateGalleries/ui/GalleryNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateGalleries/ui/GalleryNavMenuAsDropdown.tsx
@@ -1,5 +1,5 @@
 'use client';
-import { useParams } from 'next/navigation';
+import { useParams, useRouter } from 'next/navigation';
 import {
     NavMenuWithDropdowns,
     NavMenuWithDropdownsProps,
@@ -18,28 +18,37 @@ const GalleryNavMenuAsDropdown = (props: GalleryNavMenuProps) => {
     const { openByDefault = false } = props;
 
     const params = useParams();
+    const router = useRouter();
     const lng = params.lng as string;
     const currentCategory = params.category as string;
     const language = getLanguageCode(lng);
     const { categories } = useGetDirectusGalleryImages(language);
-    const allCategory = { name: lng === 'en' ? 'All' : 'Kaikki' };
-    const [selectedCategory, setSelectedCategory] = useState(allCategory.name.toLowerCase());
+    const allCategory = { name: lng === 'en' ? 'all' : 'kaikki' };
+    const extendedCategories = [allCategory, ...categories];
+    const [selectedCategory, setSelectedCategory] = useState(currentCategory || allCategory.name);
 
     useEffect(() => {
         if (currentCategory) setSelectedCategory(currentCategory);
     }, [currentCategory]);
 
-    const extendedCategories = [allCategory, ...categories];
+    useEffect(() => {
+        if (selectedCategory !== allCategory.name) {
+            setSelectedCategory(allCategory.name);
+            const newPath = getRouteGalleryCategoryPage(allCategory.name);
+            router.replace(newPath);
+        }
+    }, [lng]);
+
     const title = lng === 'en' ? 'Categories' : 'Kategoriat';
 
     const dropdownItems = extendedCategories.map((category) => ({
         link: {
             isExternal: false,
-            path: getRouteGalleryCategoryPage(category.name.toLowerCase()),
+            path: getRouteGalleryCategoryPage(category.name),
         },
         elementText:
             category.name.charAt(0).toUpperCase() + category.name.slice(1).replace('-', ' '),
-        active: category.name.toLowerCase() === selectedCategory,
+        active: category.name === selectedCategory,
     })) as DropDownElementASTextOrLink[];
 
     const navMenuWithDropdownsProps: NavMenuWithDropdownsProps = {

--- a/frontend-next-migration/src/preparedPages/PictureGalleryPages/ui/PictureGalleryPage.tsx
+++ b/frontend-next-migration/src/preparedPages/PictureGalleryPages/ui/PictureGalleryPage.tsx
@@ -3,7 +3,12 @@ import { useParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 import { SectionGalleryV2 } from '@/widgets/SectionGallery';
 import { GalleryNavMenuAsDropdown } from '@/features/NavigateGalleries';
-import { useGetDirectusGalleryImages, getLanguageCode, PhotoObject } from '@/entities/Gallery';
+import {
+    useGetDirectusGalleryImages,
+    getLanguageCode,
+    PhotoObject,
+    getCategoryTranslation,
+} from '@/entities/Gallery';
 import { Container } from '@/shared/ui/Container';
 import useSizes from '@/shared/lib/hooks/useSizes';
 import cls from './PictureGalleryPage.module.scss';
@@ -36,7 +41,9 @@ const PictureGalleryPage = (props: Props) => {
             setSelectedCategory(category);
             setFilteredImages(
                 photoObjects.filter(
-                    (photo) => photo.category.name.toLowerCase() === selectedCategory,
+                    (photo) =>
+                        getCategoryTranslation(photo.category.translations, language) ===
+                        selectedCategory,
                 ),
             );
         }


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes #318 

## 🔧 **Changes Made**

1. Updates url category slug to the corresponding category name translation when language is changed.

2. Change Cateogry types name field to translations.

3. Update useGetDirectusGalleryImages to return category collections translations as they are so the category name can be translated in GalleryNavMenuAsDropdown when the websites language is changed.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---