### PR TITLE
Lauri/bug/343 cookiespage text alignment

### DIFF
--- a/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContent.stories.tsx
+++ b/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContent.stories.tsx
@@ -75,6 +75,13 @@ export const Example: Story = {
                 image: 'https://altzone.fi/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fhannu-hodari.755680ec.png&w=1920&q=75',
                 imageAlt: 'Image 3',
             },
+            {
+                id: 'section4',
+                label: 'Section 4 This is a long word: Hydrochlorofluorocarbon',
+                description: 'Description for section 4',
+                image: 'https://altzone.fi/_next/image?url=%2F_next%2Fstatic%2Fmedia%2Fpirate.9a5e151f.png&w=1920&q=75',
+                imageAlt: 'Image 4',
+            },
         ],
     },
 };

--- a/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
+++ b/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
@@ -167,4 +167,5 @@
   padding: 0;
   font-size: 1.2em;
   margin: 15px;
+  word-wrap: break-word;
 }

--- a/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
+++ b/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
@@ -24,7 +24,7 @@
 }
 
 .mainContent.isMobile {
-  display:block;
+  padding: 15px;
 }
 
 .navbarSide {
@@ -167,10 +167,10 @@
 .content.isMobile {
   display: flex;
   flex-direction: column;
-  width: auto;
+  width: 100%;
   padding: 0;
   font-size: 1.2em;
-  margin: 15px;
+  margin: auto;
 
   a {
     word-wrap: break-word;

--- a/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
+++ b/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
@@ -23,6 +23,10 @@
   overflow: visible; // Ensure this is set
 }
 
+.mainContent.isMobile {
+  display:block;
+}
+
 .navbarSide {
   position: sticky;
   top: 9.5rem;

--- a/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
+++ b/frontend-next-migration/src/shared/ui/WikiContentWithSidebar/ui/WikiContentWithSideBar.module.scss
@@ -167,5 +167,8 @@
   padding: 0;
   font-size: 1.2em;
   margin: 15px;
-  word-wrap: break-word;
+
+  a {
+    word-wrap: break-word;
+  }
 }


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes #343

## 🔧 **Changes Made**

shared\ui\WikiContentWithSidebar\ui\WikiContentWithSideBar.module.scss
shared\ui\WikiContentWithSidebar\ui\WikiContent.stories.tsx

1. [Briefly describe changes you made]

I updated only 2 `.isMobile` classes in .scss.

I used the `word-wrap` property in links (a) that are in `.content` class because url-address in `cookies page` went off the screen when using small mobile device in the chrome dev tools. 
I did not use the word-wrap in other places because if it affects other words it would not be so readable.

I added a new section to the `WikiContent.stories.tsx`. This was because no other story section had a long word in it.

2. [Any refactoring or clean-up tasks]

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: [Include any screenshots or videos if the changes affect the UI]
- **Dependencies**: [Mention any new dependencies or breaking changes]
- **Known Issues**: [List any known issues or limitations]

**Pages that were affected by this issue:**
- altzone.fi/fi/cookies
- altzone.fi/fi/privacy

I did not find this issue affecting pages using the `WikiContent` component. Only pages with the `WikiContentWithSideBar` component seem to have this issue.

I used both **chrome** and **firefox dev tools** when fixing this issue.

I also noticed that in the **privacy page** some long h2 text went off the screen when using a small mobile device (344x882px, in chrome dev tools).


![text_overflow_344x882](https://github.com/user-attachments/assets/bf8616c6-170f-4800-9c68-2b7b7db47e9e)

*Long h2 text went off the screen (344 x 882 px mobile)*

![url_with_word_wrap](https://github.com/user-attachments/assets/315b6a1f-0f94-4b88-800d-d3dc45fbaabb)

*Url with word-wrap (used small mobile viewport)*