### PR TITLE
Jarno/feature/84-add-sitemap

### DIFF
--- a/frontend-next-migration/public/en/sitemap.xml
+++ b/frontend-next-migration/public/en/sitemap.xml
@@ -1,55 +1,55 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
-    <loc>https://altzone.fi/fi</loc>
+    <loc>https://altzone.fi/en</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>always</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/news</loc>
+    <loc>https://altzone.fi/en/news</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.9</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/heroes</loc>
+    <loc>https://altzone.fi/en/heroes</loc>
     <lastmod>2025-01-23</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/hero-development</loc>
+    <loc>https://altzone.fi/en/hero-development</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.5</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/clans</loc>
+    <loc>https://altzone.fi/en/clans</loc>
     <lastmod>2025-01-23</lastmod>
     <changefreq>daily</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/picture-galleries</loc>
+    <loc>https://altzone.fi/en/picture-galleries</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.6</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/comics</loc>
+    <loc>https://altzone.fi/en/comics</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.4</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/furniture</loc>
+    <loc>https://altzone.fi/en/furniture</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/artGame</loc>
+    <loc>https://altzone.fi/en/artGame</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>

--- a/frontend-next-migration/public/en/sitemap.xml
+++ b/frontend-next-migration/public/en/sitemap.xml
@@ -55,13 +55,13 @@
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/join-us</loc>
+    <loc>https://altzone.fi/en/join-us</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
-    <loc>https://altzone.fi/fi/team</loc>
+    <loc>https://altzone.fi/en/team</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>weekly</changefreq>
     <priority>0.5</priority>

--- a/frontend-next-migration/public/fi/sitemap.xml
+++ b/frontend-next-migration/public/fi/sitemap.xml
@@ -10,6 +10,60 @@
     <loc>https://altzone.fi/fi/news</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>daily</changefreq>
-    <priority>1.0</priority>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/heroes</loc>
+    <lastmod>2025-01-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/hero-development</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/clans</loc>
+    <lastmod>2025-01-23</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/picture-galleries</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/comics</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/furniture</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/artGame</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/join-us</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/team</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/frontend-next-migration/public/fi/sitemap.xml
+++ b/frontend-next-migration/public/fi/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://altzone.fi</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>always</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/news</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/frontend-next-migration/public/robots.txt
+++ b/frontend-next-migration/public/robots.txt
@@ -1,4 +1,6 @@
 User-agent: *
-Disallow:
+Allow: /
 
 Sitemap: https://altzone.fi/sitemap.xml
+Sitemap: https://altzone.fi/fi/sitemap.xml
+Sitemap: https://altzone.fi/en/sitemap.xml

--- a/frontend-next-migration/public/sitemap.xml
+++ b/frontend-next-migration/public/sitemap.xml
@@ -10,6 +10,60 @@
     <loc>https://altzone.fi/fi/news</loc>
     <lastmod>2025-01-22</lastmod>
     <changefreq>daily</changefreq>
-    <priority>1.0</priority>
+    <priority>0.9</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/heroes</loc>
+    <lastmod>2025-01-23</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/hero-development</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.5</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/clans</loc>
+    <lastmod>2025-01-23</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/picture-galleries</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>monthly</changefreq>
+    <priority>0.6</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/comics</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.4</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/furniture</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/artGame</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/join-us</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>yearly</changefreq>
+    <priority>0.3</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/team</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>0.5</priority>
   </url>
 </urlset>

--- a/frontend-next-migration/public/sitemap.xml
+++ b/frontend-next-migration/public/sitemap.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://altzone.fi</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>always</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <url>
+    <loc>https://altzone.fi/fi/news</loc>
+    <lastmod>2025-01-22</lastmod>
+    <changefreq>daily</changefreq>
+    <priority>1.0</priority>
+  </url>
+</urlset>

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -1,4 +1,7 @@
 import type { MetadataRoute } from 'next';
+import { envHelper } from '@/shared/const/envHelper';
+
+export const dynamic = 'force-static';
 
 /**
  * Generate a sitemap.xml file.
@@ -7,71 +10,72 @@ import type { MetadataRoute } from 'next';
  * @property {'always'|'daily'|'weekly'|'monthly'|'yearly'|'never'} changefreq - Page change frequency.
  * @property {number} priority - Page importance (0.0-1.0).
  */
+const BASE_URL = envHelper.appDomain || 'https://altzone.fi';
 
 export default function sitemap(): MetadataRoute.Sitemap {
     return [
         {
-            url: 'https://altzone.fi',
+            url: `${BASE_URL}`,
             lastModified: new Date(),
             changeFrequency: 'always',
             priority: 1.0,
         },
         {
-            url: 'https://altzone.fi/fi/news',
+            url: `${BASE_URL}/fi/news`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.9,
         },
         {
-            url: 'https://altzone.fi/fi/heroes',
+            url: `${BASE_URL}/fi/heroes`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.8,
         },
         {
-            url: 'https://altzone.fi/fi/hero-development',
+            url: `${BASE_URL}/fi/hero-development`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.5,
         },
         {
-            url: 'https://altzone.fi/fi/clans',
+            url: `${BASE_URL}/fi/clans`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.8,
         },
         {
-            url: 'https://altzone.fi/fi/picture-galleries',
+            url: `${BASE_URL}/fi/picture-galleries`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.6,
         },
         {
-            url: 'https://altzone.fi/fi/comics',
+            url: `${BASE_URL}/fi/comics`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.4,
         },
         {
-            url: 'https://altzone.fi/fi/furniture',
+            url: `${BASE_URL}/fi/furniture`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.8,
         },
         {
-            url: 'https://altzone.fi/fi/artGame',
+            url: `${BASE_URL}/fi/artGame`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: 'https://altzone.fi/fi/join-us',
+            url: `${BASE_URL}/fi/join-us`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: 'https://altzone.fi/fi/team',
+            url: `${BASE_URL}/fi/team`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.5,

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -10,7 +10,7 @@ export const dynamic = 'force-static';
  * @property {'always'|'daily'|'weekly'|'monthly'|'yearly'|'never'} changefreq - Page change frequency.
  * @property {number} priority - Page importance (0.0-1.0).
  */
-const BASE_URL = envHelper.appDomain || 'https://altzone.fi';
+const BASE_URL = envHelper.appDomain;
 
 export default function sitemap(): MetadataRoute.Sitemap {
     return [

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -20,13 +20,13 @@ export default function sitemap(): MetadataRoute.Sitemap {
             url: 'https://altzone.fi/fi/news',
             lastModified: new Date(),
             changeFrequency: 'daily',
-            priority: 1.0,
+            priority: 0.9,
         },
         {
             url: 'https://altzone.fi/fi/heroes',
             lastModified: new Date(),
             changeFrequency: 'monthly',
-            priority: 0.5,
+            priority: 0.8,
         },
         {
             url: 'https://altzone.fi/fi/hero-development',
@@ -38,7 +38,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
             url: 'https://altzone.fi/fi/clans',
             lastModified: new Date(),
             changeFrequency: 'daily',
-            priority: 0.9,
+            priority: 0.8,
         },
         {
             url: 'https://altzone.fi/fi/picture-galleries',
@@ -55,7 +55,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
         {
             url: 'https://altzone.fi/fi/furniture',
             lastModified: new Date(),
-            changeFrequency: 'monthly',
+            changeFrequency: 'weekly',
             priority: 0.8,
         },
         {

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from 'next';
+
+export default function sitemap(): MetadataRoute.Sitemap {
+    return [
+        {
+            url: 'https://altzone.fi',
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 1,
+        },
+        {
+            url: 'https://altzone.fi/news',
+            lastModified: new Date(),
+            changeFrequency: 'weekly',
+            priority: 0.8,
+        },
+        {
+            url: 'https://altzone.fi/heroes',
+            lastModified: new Date(),
+            changeFrequency: 'yearly',
+            priority: 0.5,
+        },
+    ];
+}

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -5,7 +5,7 @@ export const dynamic = 'force-static';
 
 /**
  * Generate a sitemap.xml file.
- * @constant {string} BASE_URL - The base domain for all URLs, fetched from envHelper.
+ * @constant {string} siteUrl - The base domain for all URLs, fetched from envHelper.
  * @returns {MetadataRoute.Sitemap} A Sitemap object that contains page URLs and other information.
  * @property {string} url - Page URL.
  * @property {Date} lastModified - The last modification date of the page.
@@ -22,72 +22,72 @@ export const dynamic = 'force-static';
  * ]
  */
 
-const baseUrl = envHelper.appDomain;
+const siteUrl = envHelper.appDomain;
 
 export default function sitemap(): MetadataRoute.Sitemap {
     return [
         {
-            url: `${baseUrl}`,
+            url: `${siteUrl}`,
             lastModified: new Date(),
             changeFrequency: 'always',
             priority: 1.0,
         },
         {
-            url: `${baseUrl}/fi/news`,
+            url: `${siteUrl}/fi/news`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.9,
         },
         {
-            url: `${baseUrl}/fi/heroes`,
+            url: `${siteUrl}/fi/heroes`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.8,
         },
         {
-            url: `${baseUrl}/fi/hero-development`,
+            url: `${siteUrl}/fi/hero-development`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.5,
         },
         {
-            url: `${baseUrl}/fi/clans`,
+            url: `${siteUrl}/fi/clans`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.8,
         },
         {
-            url: `${baseUrl}/fi/picture-galleries`,
+            url: `${siteUrl}/fi/picture-galleries`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.6,
         },
         {
-            url: `${baseUrl}/fi/comics`,
+            url: `${siteUrl}/fi/comics`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.4,
         },
         {
-            url: `${baseUrl}/fi/furniture`,
+            url: `${siteUrl}/fi/furniture`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.8,
         },
         {
-            url: `${baseUrl}/fi/artGame`,
+            url: `${siteUrl}/fi/artGame`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: `${baseUrl}/fi/join-us`,
+            url: `${siteUrl}/fi/join-us`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: `${baseUrl}/fi/team`,
+            url: `${siteUrl}/fi/team`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.5,

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -5,11 +5,23 @@ export const dynamic = 'force-static';
 
 /**
  * Generate a sitemap.xml file.
+ * @constant {string} BASE_URL - The base domain for all URLs, fetched from envHelper.
  * @returns {MetadataRoute.Sitemap} A Sitemap object that contains page URLs and other information.
  * @property {string} url - Page URL.
+ * @property {Date} lastModified - The last modification date of the page.
  * @property {'always'|'daily'|'weekly'|'monthly'|'yearly'|'never'} changefreq - Page change frequency.
  * @property {number} priority - Page importance (0.0-1.0).
+ * Example usage:
+ * [
+ *   {
+ *     url: "https://altzone.fi/fi/news",
+ *     lastModified: new Date(),
+ *     changeFrequency: "daily",
+ *     priority: 0.9
+ *   }
+ * ]
  */
+
 const BASE_URL = envHelper.appDomain;
 
 export default function sitemap(): MetadataRoute.Sitemap {

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -22,72 +22,72 @@ export const dynamic = 'force-static';
  * ]
  */
 
-const BASE_URL = envHelper.appDomain;
+const baseUrl = envHelper.appDomain;
 
 export default function sitemap(): MetadataRoute.Sitemap {
     return [
         {
-            url: `${BASE_URL}`,
+            url: `${baseUrl}`,
             lastModified: new Date(),
             changeFrequency: 'always',
             priority: 1.0,
         },
         {
-            url: `${BASE_URL}/fi/news`,
+            url: `${baseUrl}/fi/news`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.9,
         },
         {
-            url: `${BASE_URL}/fi/heroes`,
+            url: `${baseUrl}/fi/heroes`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.8,
         },
         {
-            url: `${BASE_URL}/fi/hero-development`,
+            url: `${baseUrl}/fi/hero-development`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.5,
         },
         {
-            url: `${BASE_URL}/fi/clans`,
+            url: `${baseUrl}/fi/clans`,
             lastModified: new Date(),
             changeFrequency: 'daily',
             priority: 0.8,
         },
         {
-            url: `${BASE_URL}/fi/picture-galleries`,
+            url: `${baseUrl}/fi/picture-galleries`,
             lastModified: new Date(),
             changeFrequency: 'monthly',
             priority: 0.6,
         },
         {
-            url: `${BASE_URL}/fi/comics`,
+            url: `${baseUrl}/fi/comics`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.4,
         },
         {
-            url: `${BASE_URL}/fi/furniture`,
+            url: `${baseUrl}/fi/furniture`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.8,
         },
         {
-            url: `${BASE_URL}/fi/artGame`,
+            url: `${baseUrl}/fi/artGame`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: `${BASE_URL}/fi/join-us`,
+            url: `${baseUrl}/fi/join-us`,
             lastModified: new Date(),
             changeFrequency: 'yearly',
             priority: 0.3,
         },
         {
-            url: `${BASE_URL}/fi/team`,
+            url: `${baseUrl}/fi/team`,
             lastModified: new Date(),
             changeFrequency: 'weekly',
             priority: 0.5,

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -1,23 +1,79 @@
 import type { MetadataRoute } from 'next';
 
+/**
+ * Generate a sitemap.xml file.
+ * @returns {MetadataRoute.Sitemap} A Sitemap object that contains page URLs and other information.
+ * @property {string} url - Page URL.
+ * @property {'always'|'daily'|'weekly'|'monthly'|'yearly'|'never'} changefreq - Page change frequency.
+ * @property {number} priority - Page importance (0.0-1.0).
+ */
+
 export default function sitemap(): MetadataRoute.Sitemap {
     return [
         {
             url: 'https://altzone.fi',
             lastModified: new Date(),
-            changeFrequency: 'monthly',
-            priority: 1,
+            changeFrequency: 'always',
+            priority: 1.0,
         },
         {
-            url: 'https://altzone.fi/news',
+            url: 'https://altzone.fi/fi/news',
             lastModified: new Date(),
-            changeFrequency: 'weekly',
+            changeFrequency: 'daily',
+            priority: 1.0,
+        },
+        {
+            url: 'https://altzone.fi/fi/heroes',
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.5,
+        },
+        {
+            url: 'https://altzone.fi/fi/hero-development',
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.5,
+        },
+        {
+            url: 'https://altzone.fi/fi/clans',
+            lastModified: new Date(),
+            changeFrequency: 'daily',
+            priority: 0.9,
+        },
+        {
+            url: 'https://altzone.fi/fi/picture-galleries',
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
+            priority: 0.6,
+        },
+        {
+            url: 'https://altzone.fi/fi/comics',
+            lastModified: new Date(),
+            changeFrequency: 'yearly',
+            priority: 0.4,
+        },
+        {
+            url: 'https://altzone.fi/fi/furniture',
+            lastModified: new Date(),
+            changeFrequency: 'monthly',
             priority: 0.8,
         },
         {
-            url: 'https://altzone.fi/heroes',
+            url: 'https://altzone.fi/fi/artGame',
             lastModified: new Date(),
             changeFrequency: 'yearly',
+            priority: 0.3,
+        },
+        {
+            url: 'https://altzone.fi/fi/join-us',
+            lastModified: new Date(),
+            changeFrequency: 'yearly',
+            priority: 0.3,
+        },
+        {
+            url: 'https://altzone.fi/fi/team',
+            lastModified: new Date(),
+            changeFrequency: 'weekly',
             priority: 0.5,
         },
     ];

--- a/frontend-next-migration/src/app/sitemap.ts
+++ b/frontend-next-migration/src/app/sitemap.ts
@@ -22,7 +22,7 @@ export const dynamic = 'force-static';
  * ]
  */
 
-const siteUrl = envHelper.appDomain;
+const siteUrl = `https://${envHelper.appDomain}`;
 
 export default function sitemap(): MetadataRoute.Sitemap {
     return [

--- a/frontend-next-migration/src/shared/const/envHelper.ts
+++ b/frontend-next-migration/src/shared/const/envHelper.ts
@@ -15,7 +15,7 @@
 export const envHelper = {
     isDevMode: process.env.NODE_ENV === 'development',
     apiLink: process.env.NEXT_PUBLIC_API_LINK || '',
-    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || '',
+    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'https://altzone.fi',
     companyName: process.env.COMPANY_NAME || "Psyche's Royale Gaming ry",
     strapiHost: process.env.NEXT_PUBLIC_STRAPI_HOST || '',
     directusHost: process.env.NEXT_PUBLIC_DIRECTUS_HOST || '',

--- a/frontend-next-migration/src/shared/const/envHelper.ts
+++ b/frontend-next-migration/src/shared/const/envHelper.ts
@@ -15,7 +15,7 @@
 export const envHelper = {
     isDevMode: process.env.NODE_ENV === 'development',
     apiLink: process.env.NEXT_PUBLIC_API_LINK || '',
-    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'https://altzone.fi',
+    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'altzone.fi',
     companyName: process.env.COMPANY_NAME || "Psyche's Royale Gaming ry",
     strapiHost: process.env.NEXT_PUBLIC_STRAPI_HOST || '',
     directusHost: process.env.NEXT_PUBLIC_DIRECTUS_HOST || '',

--- a/frontend-next-migration/src/shared/const/envHelper.ts
+++ b/frontend-next-migration/src/shared/const/envHelper.ts
@@ -15,7 +15,7 @@
 export const envHelper = {
     isDevMode: process.env.NODE_ENV === 'development',
     apiLink: process.env.NEXT_PUBLIC_API_LINK || '',
-    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'altzone.fi',
+    appDomain: process.env.NEXT_PUBLIC_APP_DOMAIN || 'https://altzone.fi',
     companyName: process.env.COMPANY_NAME || "Psyche's Royale Gaming ry",
     strapiHost: process.env.NEXT_PUBLIC_STRAPI_HOST || '',
     directusHost: process.env.NEXT_PUBLIC_DIRECTUS_HOST || '',

--- a/frontend-next-migration/src/stories/Sitemap.stories.tsx
+++ b/frontend-next-migration/src/stories/Sitemap.stories.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import sitemap from '../app/sitemap';
+
+export default {
+    title: 'Sitemap',
+};
+
+export const SitemapStory = () => {
+    const sitemapData = sitemap();
+
+    const containerStyle: React.CSSProperties = {
+        fontFamily: 'monospace',
+        whiteSpace: 'pre-wrap',
+        padding: '16px',
+        backgroundColor: '#ffffff',
+        color: '#333333',
+    };
+
+    return (
+        <div style={containerStyle}>
+            <h2>Sitemap</h2>
+            <pre>{JSON.stringify(sitemapData, null, 2)}</pre>
+        </div>
+    );
+};


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes #84

## 🔧 **Changes Made**

Created sitemap.ts, which should automatically create sitemap.xml. The current next.js version does not support localization, but I made a function without it. This feature can be easily added after updating Next. I also added a general sitemap.xml file as well as fi/sitemap.xml and en/sitemap.xml, so that sitemaps work in both languages ​​when searched (localization). I created the files manually because the current Next project has either a version or configuration issue with the automatic sitemap.xml creation, which I couldn't figure out. I modified robots.txt so that search engine crawlers can find the sitemaps. Added the component to Storybook, where it worked as expected.

2. [Any refactoring or clean-up tasks]

---

## ✅ **Checklist Before Submission**

I have tested my code, and it works as expected in Storybook.
I have added or updated JSDoc comments for all relevant code.

---

## 📝 **Additional Information**

The current Next version does not support localization in the sitemap component.
Prioritization and page update information may need updating. After creating new pages, it is a good idea to update the component and the xml files.