### PR TITLE
Jari/features/388 footer feedback input field

### DIFF
--- a/frontend-next-migration/src/features/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/features/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -78,14 +78,14 @@
     gap: 10px;
 }
 .linkToFormContainer {
-    display: flex; /* Aktivoi flexbox-asettelu */
-    flex-direction: row; /* Varmistaa, että sisältö on rivillä */
-    gap: 10px; /* Lisää tilaa elementtien väliin */
+    display: flex;
+    flex-direction: row;
+    gap: 10px;
 }
 
 .linkToFormContainer > * {
-    display: inline-block; /* Varautuu block-tilan oletukseen */
-    vertical-align: middle; /* Sijoittaa tekstin pystysuunnassa keskelle */
+    display: inline-block;
+    vertical-align: middle;
 }
 
 

--- a/frontend-next-migration/src/features/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/features/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -21,7 +21,7 @@
     font-size: 24px;
     line-height: 32px;
 
-    color: #FFA101;
+    color: #FF0010;
 };
 
 

--- a/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -1,3 +1,9 @@
+/*
+     On the row 62 in .textInput, the height was 40px which is why it did not
+     match the text input on Figma. I set the height to 45px and now it does match the requirements
+ */
+
+
 .feedbackForm {
     background-color: #1E3544;
     display: flex;

--- a/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -3,7 +3,6 @@
      match the text input on Figma. I set the height to 45px and now it does match the requirements
  */
 
-
 .feedbackForm {
     background-color: #1E3544;
     display: flex;

--- a/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -1,10 +1,5 @@
-/*
-     On the row 62 in .textInput, the height was 40px which is why it did not
-     match the text input on Figma. I set the height to 45px and now it does match the requirements
- */
-
 .feedbackForm {
-    background-color: #1E3544;
+    background-color: var(--base-card-background);
     display: flex;
     flex-direction: column;
     margin: 5px;
@@ -27,7 +22,7 @@
     padding: 5px 1em 0 1em;
     height: fit-content;
     color: var(--secondary-color);
-    font-family: var(--font-family-title);
+    font-family: var(--font-family-title),serif;
     text-align: center;
     width: 100%;
     margin: 0 auto;
@@ -49,7 +44,7 @@
     width: 300px;
     height: 48px;
     background: var(--secondary-color) !important;
-    border: 2px solid #000000 !important;
+    border: 2px solid var(--drop-shadows) !important;
     border-radius: 25px !important;
     box-shadow: 2px 4px 0 #121212 !important;
 }
@@ -80,7 +75,7 @@
 .linkToForm {
     display: flex;
     flex-direction: row;
-    font-family: var(--font-family-secondary);
+    font-family: var(--font-family-secondary) serif;
     font-size: 1rem;
 }
 

--- a/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/Feedback/ui/FeedbackCard/FeedbackCard.module.scss
@@ -8,7 +8,7 @@
     padding-top: 0;
     align-items: center;
     gap: 10px;
-    box-shadow: 6px 8px 1px #000000;
+    box-shadow: 8px 8px 1px #000000;
     border-width: 4px;
     border-style: solid;
     border-color: #000000;
@@ -21,7 +21,7 @@
     line-height: 40px;
     padding: 5px 1em 0 1em;
     height: fit-content;
-    color: var(--secondary-color) !important;
+    color: var(--secondary-color);
     font-family: var(--font-family-title);
     text-align: center;
     width: 100%;
@@ -54,7 +54,7 @@
     font-family: var(--font-family-texts), sans-serif;
     color: var(--inverted-bg-color);
     width: 100%;
-    height: 40px;
+    height: 45px;
     padding: 0 10px;
     background: #FFFFFF;
     border: 2px solid #000000;


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes 388

## 🔧 **Changes Made**

1. I could change the design of the text input in the feedback card from the footer of the main page. It happened in the file FeedbackCard.module.scss. The height was 40px but it is now 45px as it is supposed to be for matching the Figma design.

2.  -

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

1. I only did the second part of the issue regarding changing the text input. I tried to solve the problem with a multiple rendering but I could not find any concrete solutions.

2. There is already the correct and matching design of the text input in the Storybook.  

The result after changing the text input:

![image](https://github.com/user-attachments/assets/e7e8f2db-82c9-4ee7-b9e8-ef9da3d99c78)
