### PR TITLE
Kaisa/enhancement/413 update homepage texts to match figma design

### DIFF
--- a/frontend-next-migration/src/app/[lng]/(home)/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(home)/_getPage.ts
@@ -44,8 +44,8 @@ export async function _getPage(lng: string) {
                 webGlNotice: t('playWithUs-WebGLNotice'),
             },
             projectDescription: {
-                title: t('project-description-title'),
-                description: t('project-description-text'),
+                title: t('main-title'),
+                description: t('main-description'),
                 descriptionArray: t('project-description-array', {
                     returnObjects: true,
                 }) as unknown as string[],

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
@@ -92,6 +92,10 @@
 
 .titleQuestion {
   font-size: var(--font-line-xxxl);
+  font-family: var(--font-family-title);
+  text-align: center;
+  color: var(--primary-color);
+  padding: 15px;
 
  @media screen and (max-width: 600px) {
    & {

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
@@ -50,7 +50,7 @@
 .imageTextBlock {
   display: flex;
   align-items: center;
-  max-width: 90%;
+  max-width: 80%;
   margin-top: 20px;
   transform: scale(0.8);
   opacity: 0;
@@ -92,11 +92,12 @@
 
 .titleQuestion {
   font-size: var(--font-line-xxxl);
-  font-family: var(--font-family-title);
+  font-family: var(--font-family-title), sans-serif;
   font-weight: lighter;
   text-align: center;
   color: var(--primary-color);
   padding: 15px;
+  max-width: 90%;
 
  @media screen and (max-width: 600px) {
    & {

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
@@ -110,3 +110,10 @@
   }
 
 }
+
+@media screen and (min-width: breakpoint(lg)) {
+  .description {
+    width: 60%;
+  }
+}
+

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.module.scss
@@ -93,6 +93,7 @@
 .titleQuestion {
   font-size: var(--font-line-xxxl);
   font-family: var(--font-family-title);
+  font-weight: lighter;
   text-align: center;
   color: var(--primary-color);
   padding: 15px;

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
@@ -47,11 +47,6 @@ export const ProjectDescription = (props: Props) => {
                         />
                     )}
 
-                    {/* <TextSlider
-                        textArray={descriptionArray}
-                        className={cls.description}
-                    /> */}
-
                     <Paragraph
                         className={cls.description}
                         text={description}

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
@@ -5,8 +5,9 @@ import { classNames } from '@/shared/lib/classNames/classNames';
 import greenHaired from '@/shared/assets/images/heros/hannu-hodari/ahmatti_2_60.webp';
 import { Container } from '@/shared/ui/Container';
 import useIsMobileSize from '@/shared/lib/hooks/useIsMobileSize';
-import TextSlider from '@/shared/ui/TextSlider/TextSlider';
+// import TextSlider from '@/shared/ui/TextSlider/TextSlider';
 import cls from './ProjectDescription.module.scss';
+import { Paragraph } from '@/shared/ui/Paragraph';
 
 export interface Props {
     className?: string;
@@ -46,9 +47,14 @@ export const ProjectDescription = (props: Props) => {
                         />
                     )}
 
-                    <TextSlider
+                    {/* <TextSlider
                         textArray={descriptionArray}
                         className={cls.description}
+                    /> */}
+
+                    <Paragraph
+                        className={cls.description}
+                        text={description}
                     />
                 </div>
             </Container>

--- a/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
+++ b/frontend-next-migration/src/preparedPages/MainPage/ui/_components/sections/ProjectDescription/ProjectDescription.tsx
@@ -5,7 +5,6 @@ import { classNames } from '@/shared/lib/classNames/classNames';
 import greenHaired from '@/shared/assets/images/heros/hannu-hodari/ahmatti_2_60.webp';
 import { Container } from '@/shared/ui/Container';
 import useIsMobileSize from '@/shared/lib/hooks/useIsMobileSize';
-// import TextSlider from '@/shared/ui/TextSlider/TextSlider';
 import cls from './ProjectDescription.module.scss';
 import { Paragraph } from '@/shared/ui/Paragraph';
 

--- a/frontend-next-migration/src/shared/i18n/locales/en/main.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/main.json
@@ -9,6 +9,9 @@
     "ranking-player": "player",
     "ranking-score": "score",
 
+    "main-title": "Let's make the best game in the world together!",
+    "main-description": "In the ALT Zone mobile game, you enter the depths of the human mind, where game characters represent defense mechanisms and face each other on the battlefield of interaction situations.",
+
     "project-description-title": "What is Alt Zone?",
     "project-description-text": "ALT Zone is a mobile game with artistic content developed for use in elementary school art education. Teaching game art is inherently challenging; it heavily relies on personal experience and analysis, and achieving a common experience is nearly impossible. ALT Zone provides a common foundation for game art education. The teaching package is easy to implement; it includes a mobile or PC-tested demo game, as well as questions guiding thinking in the field of game art. The game can also be analyzed solely through videos and images.Students have the opportunity to further develop the game and later download it from the app store as ALT Zone 2.0 - a mobile game. The proceeds from ALT Zone 2.0 will go towards supporting the dreams of youth through the foundation established for this purpose.",
     "project-description-array": [

--- a/frontend-next-migration/src/shared/i18n/locales/en/main.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/main.json
@@ -9,7 +9,7 @@
     "ranking-player": "player",
     "ranking-score": "score",
 
-    "main-title": "Let's make the best game in the world together!",
+    "main-title": "LET'S MAKE THE BEST GAME IN THE WORLD TOGETHER!",
     "main-description": "In the ALT Zone mobile game, you enter the depths of the human mind, where game characters represent defense mechanisms and face each other on the battlefield of interaction situations.",
 
     "project-description-title": "What is Alt Zone?",

--- a/frontend-next-migration/src/shared/i18n/locales/fi/main.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/main.json
@@ -9,6 +9,9 @@
     "ranking-player": "pelaaja",
     "ranking-score": "pisteet",
 
+    "main-title": "Tehdään yhdessä maailman paras peli!",
+    "main-description": "ALT Zone -mobiilipelissä astut ihmismielen syövereihin, jossa pelihahmot edustavat suojautumismekanismeja ja kohtaavat toisensa vuorovaikutustilanteiden taistelukentällä.",
+
     "project-description-title": "Mitä on Alt Zone?",
     "project-description-text": "ALT Zone on taiteellisella sisällöllä varustettu mobiilipeli, jota kehitetään peruskoulujen taideopetuksen opetusvälineeksi. Pelitaiteen opetus on itsessään haastavaa, opetus perustuu vahvasti omakohtaiseen kokemukseen ja analysointiin, yhteistä kokemusta on lähes mahdotonta saavuttaa. ALT Zone tarjoaa yhteisen pohjan pelitaiteen opetukselle. Opetuspaketti on helppo toteuttaa; se sisältää mobiili- tai pc-laitteella testattavan demopelin, sekä pelitaiteen ajatteluun ohjaavia kysymyksiä. Peliä voidaan myös analysoida pelkästään videoiden ja kuvien avulla. Oppilailla on mahdollisuus jatkokehittää peliä sovelluskaupasta myöhemmin ladattavaksi ALT Zone 2.0 - mobiilipeliksi. ALT Zone 2.0 pelin tuotto menee nuorten unelmien tukemiseen siihen perustettavan säätiön kautta.",
     "project-description-array": [

--- a/frontend-next-migration/src/shared/i18n/locales/fi/main.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/main.json
@@ -9,7 +9,7 @@
     "ranking-player": "pelaaja",
     "ranking-score": "pisteet",
 
-    "main-title": "Tehdään yhdessä maailman paras peli!",
+    "main-title": "TEHDÄÄN YHDESSÄ MAAILMAN PARAS PELI!",
     "main-description": "ALT Zone -mobiilipelissä astut ihmismielen syövereihin, jossa pelihahmot edustavat suojautumismekanismeja ja kohtaavat toisensa vuorovaikutustilanteiden taistelukentällä.",
 
     "project-description-title": "Mitä on Alt Zone?",


### PR DESCRIPTION
Add new title and text. Comment out TextSlider and replace it with a Paragraph. Add new font family to title.

## 📄 **Pull Request Overview**

closes #413 

## 🔧 **Changes Made**

1. Added new text and title to i18n. The texts are taken from Figma.

2. Replaced TextSlider with Paragraph and commented out the TextSlider.

3. Added new font family for the title. The `--heading-font` variable did not work so I used the `--font-family-title` variable (it is also used in Footer for example). They both have `Sedgwick Ave Display` as the font family. 

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

The text is from Figma, but styling is from the issues example image.

<img width="1324" alt="new_title_and_text" src="https://github.com/user-attachments/assets/12d15ecd-585a-4486-b0e1-3c1782c2c468" />
