### PR TITLE
Kaisa/bug/410 fix sidebar layout

### DIFF
--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
@@ -27,7 +27,7 @@ $touchSize: 1023px;
   height: calc(100vh - #{$navbar-height});
   flex-shrink: 0;
   min-width: 250px;
-  flex-basis: 25%;
+  flex-basis: 22%;
   overflow-y: auto;
   transition: min-width,flex-basis .3s ease-out;
 

--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
@@ -26,7 +26,7 @@ $touchSize: 1023px;
   top: $navbar-height;
   height: calc(100vh - #{$navbar-height});
   flex-shrink: 0;
-  min-width: 250px;
+  min-width: 300px;
   flex-basis: 22%;
   overflow-y: auto;
   transition: min-width,flex-basis .3s ease-out;

--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.module.scss
@@ -27,7 +27,7 @@ $touchSize: 1023px;
   height: calc(100vh - #{$navbar-height});
   flex-shrink: 0;
   min-width: 250px;
-  flex-basis: 20%;
+  flex-basis: 25%;
   overflow-y: auto;
   transition: min-width,flex-basis .3s ease-out;
 

--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
@@ -62,7 +62,7 @@ const LayoutWithSidebars = (props: DesktopLeftSidebarLayoutProps) => {
                 <aside
                     style={{
                         minWidth: collapsed ? '1em' : '250px',
-                        flexBasis: collapsed ? '1em' : '20%',
+                        flexBasis: collapsed ? '1em' : '25%',
                         overflowX: collapsed ? 'hidden' : 'auto',
                         top: !isTopIndentCustom ? '50px' : undefined,
                     }}

--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
@@ -61,7 +61,7 @@ const LayoutWithSidebars = (props: DesktopLeftSidebarLayoutProps) => {
             {leftTopSidebar && (
                 <aside
                     style={{
-                        minWidth: collapsed ? '1em' : '250px',
+                        minWidth: collapsed ? '1em' : '300px',
                         flexBasis: collapsed ? '1em' : '22%',
                         overflowX: collapsed ? 'hidden' : 'auto',
                         top: !isTopIndentCustom ? '50px' : undefined,

--- a/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
+++ b/frontend-next-migration/src/preparedPages/Layouts/ui/LayoutWithSidebars/LayoutWithSidebars.tsx
@@ -62,7 +62,7 @@ const LayoutWithSidebars = (props: DesktopLeftSidebarLayoutProps) => {
                 <aside
                     style={{
                         minWidth: collapsed ? '1em' : '250px',
-                        flexBasis: collapsed ? '1em' : '25%',
+                        flexBasis: collapsed ? '1em' : '22%',
                         overflowX: collapsed ? 'hidden' : 'auto',
                         top: !isTopIndentCustom ? '50px' : undefined,
                     }}

--- a/frontend-next-migration/src/shared/ui/MasonryWrapper/ui/MasonryWrapper.module.scss
+++ b/frontend-next-migration/src/shared/ui/MasonryWrapper/ui/MasonryWrapper.module.scss
@@ -5,6 +5,6 @@
 
 @media screen and (min-width: 800px) {
     .Container {
-        width: 85%;
+        width: 90%;
     }
 }

--- a/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.module.scss
+++ b/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.module.scss
@@ -6,7 +6,7 @@
   font-size: var(--font-size-l);
 
   // max-width can be changed but shouldnt really be necessary
-  max-width: 320px;
+  max-width: 280px;
 
   @media (max-width: breakpoint(lg)) {
     width: 50%;


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes #410 

## 🔧 **Changes Made**

1. Make sidebar little wider in the LayoutWithSidebars so the dropdown components dropshadow will be visible in the right side.

2. Additionally made the MasonryWrapper a bit wider so images will get more space in the gallery page. Did this because the sidebar takes a bit more space now.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.

---

