### PR TITLE
Jarno/bug/400-bug-report-scroll-top-overlap

### DIFF
--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
@@ -17,7 +17,7 @@
   height: 70px;
   padding:0 !important;
   position: fixed;
-  bottom: 330px; // 100px + 70px + 16px + 70px
+  bottom: 266px; // 100px + 70px + 16px + 70px Original Space 330px
   right: 5px;
   opacity: 0;
   visibility: hidden;

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
@@ -26,7 +26,7 @@
     width:60px;
     height:60px;
     right: 16px;
-    bottom: 240px;
+    bottom: 266px;
     border-width: var(--border-mobile)!important;
     border-radius: calc(var(--border-radius-custom !important) * 1.5);
   }

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
@@ -26,7 +26,7 @@
     width:60px;
     height:60px;
     right: 16px;
-    bottom: 266px;
+    bottom: 240px; // Original Space 266px
     border-width: var(--border-mobile)!important;
     border-radius: calc(var(--border-radius-custom !important) * 1.5);
   }

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.module.scss
@@ -17,7 +17,7 @@
   height: 70px;
   padding:0 !important;
   position: fixed;
-  bottom: 266px; // 100px + 70px + 16px + 70px Original Space 330px
+  bottom: 266px;
   right: 5px;
   opacity: 0;
   visibility: hidden;
@@ -26,7 +26,7 @@
     width:60px;
     height:60px;
     right: 16px;
-    bottom: 240px; // Original Space 266px
+    bottom: 240px;
     border-width: var(--border-mobile)!important;
     border-radius: calc(var(--border-radius-custom !important) * 1.5);
   }

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -64,7 +64,7 @@ describe('ScrollTop', () => {
         Object.defineProperty(window, 'innerHeight', {
             writable: true,
             configurable: true,
-            value: 1000, // Esimerkkiarvo
+            value: 1000, // Example value
         });
 
         Object.defineProperty(document.body, 'scrollHeight', {

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import * as hooks from '@/shared/lib/hooks';
 import * as i18n from '@/shared/i18n';
 import { ScrollTop } from './ScrollTop';
+import React from 'react';
 
 // Mocking the hooks used in the ScrollTop component
 jest.mock('@/shared/lib/hooks', () => ({
@@ -56,13 +57,39 @@ describe('ScrollTop', () => {
     });
 
     it('should be visible when scrolling to the middle of the page', async () => {
-        // Mock the hook to simulate being at the middle of the page
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight * 2);
-        render(<ScrollTop />); // Render the component
+        // Mock the hook to simulate scrolling to the middle of the page
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight / 2);
 
-        // Wait for the show class to appear and t Verify that the button is visible
+        // Mock window.innerHeight ja document.body.scrollHeight
+        Object.defineProperty(window, 'innerHeight', {
+            writable: true,
+            configurable: true,
+            value: 1000, // Esimerkkiarvo
+        });
+
+        Object.defineProperty(document.body, 'scrollHeight', {
+            writable: true,
+            configurable: true,
+            value: 2000, // Example value, half of innerHeight
+        });
+
+        render(<ScrollTop />);
+
         await waitFor(() => {
             expect(screen.getByTestId('scroll-to-top-btn')).toHaveClass('show');
+        });
+
+        // Restore the original values, so they don't affect other tests
+        Object.defineProperty(window, 'innerHeight', {
+            writable: true,
+            configurable: true,
+            value: window.innerHeight,
+        });
+
+        Object.defineProperty(document.body, 'scrollHeight', {
+            writable: true,
+            configurable: true,
+            value: document.body.scrollHeight,
         });
     });
 

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -68,7 +68,7 @@ describe('ScrollTop', () => {
 
     it('should not be visible at the bottom of the page', () => {
         // Mock the hook to simulate being at the bottom of the page
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight * 2);
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight * 6);
 
         render(<ScrollTop />); // Render the component
 

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -46,38 +46,19 @@ describe('ScrollTop', () => {
         expect(button).toHaveClass('ScrollTop');
     });
 
-    it('shows button when scrolled down, but not too far', () => {
-        // Simulate page height and viewport height
-        const viewportHeight = window.innerHeight;
-        const pageHeight = 2 * viewportHeight; // Example page height
-        const scrollThreshold = viewportHeight / 6;
-        const bottomThreshold = pageHeight - viewportHeight - scrollThreshold;
-
-        // Simulate scrolling to a position where the button should be visible
-        const scrollY = (scrollThreshold + bottomThreshold) / 2;
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(scrollY);
-
-        render(<ScrollTop />);
-
-        // Simulate scroll event
-        fireEvent.scroll(window, { target: { scrollY } });
-
-        // Verify that the button is visible
-        expect(screen.getByTestId('scroll-to-top-btn')).toHaveClass('show');
-
-        // Simulate scrolling to a position where the button should be hidden
-        const scrollYNearBottom = bottomThreshold + 10;
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(scrollYNearBottom);
-
-        fireEvent.scroll(window, { target: { scrollY: scrollYNearBottom } });
+    it('hides button when scrolled up', () => {
+        // Mock the hook to simulate being at the top of the page
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(0);
+        render(<ScrollTop />); // Render the component
 
         // Verify that the button is hidden
         expect(screen.getByTestId('scroll-to-top-btn')).not.toHaveClass('show');
     });
 
-    it('hides button when scrolled up', () => {
-        // Mock the hook to simulate being at the top of the page
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(0);
+    it('should not be visible at the bottom of the page', () => {
+        // Mock the hook to simulate being at the bottom of the page
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight * 2);
+
         render(<ScrollTop />); // Render the component
 
         // Verify that the button is hidden

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -46,13 +46,33 @@ describe('ScrollTop', () => {
         expect(button).toHaveClass('ScrollTop');
     });
 
-    it('shows button when scrolled down', () => {
-        // Mock the hook to simulate scrolling down the page
-        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight / 4);
-        render(<ScrollTop />); // Render the component
+    it('shows button when scrolled down, but not too far', () => {
+        // Simulate page height and viewport height
+        const viewportHeight = window.innerHeight;
+        const pageHeight = 2 * viewportHeight; // Example page height
+        const scrollThreshold = viewportHeight / 6;
+        const bottomThreshold = pageHeight - viewportHeight - scrollThreshold;
+
+        // Simulate scrolling to a position where the button should be visible
+        const scrollY = (scrollThreshold + bottomThreshold) / 2;
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(scrollY);
+
+        render(<ScrollTop />);
+
+        // Simulate scroll event
+        fireEvent.scroll(window, { target: { scrollY } });
 
         // Verify that the button is visible
         expect(screen.getByTestId('scroll-to-top-btn')).toHaveClass('show');
+
+        // Simulate scrolling to a position where the button should be hidden
+        const scrollYNearBottom = bottomThreshold + 10;
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(scrollYNearBottom);
+
+        fireEvent.scroll(window, { target: { scrollY: scrollYNearBottom } });
+
+        // Verify that the button is hidden
+        expect(screen.getByTestId('scroll-to-top-btn')).not.toHaveClass('show');
     });
 
     it('hides button when scrolled up', () => {

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import * as hooks from '@/shared/lib/hooks';
 import * as i18n from '@/shared/i18n';
 import { ScrollTop } from './ScrollTop';
@@ -53,6 +53,17 @@ describe('ScrollTop', () => {
 
         // Verify that the button is hidden
         expect(screen.getByTestId('scroll-to-top-btn')).not.toHaveClass('show');
+    });
+
+    it('should be visible when scrolling to the middle of the page', async () => {
+        // Mock the hook to simulate being at the middle of the page
+        (hooks.useCurrentYPosition as jest.Mock).mockReturnValue(window.innerHeight * 2);
+        render(<ScrollTop />); // Render the component
+
+        // Wait for the show class to appear and t Verify that the button is visible
+        await waitFor(() => {
+            expect(screen.getByTestId('scroll-to-top-btn')).toHaveClass('show');
+        });
     });
 
     it('should not be visible at the bottom of the page', () => {

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.tsx
@@ -21,7 +21,12 @@ export const ScrollTop = memo(({ className = '' }: ScrollTopProps) => {
     const [showButton, setShowButton] = useState(false);
 
     useEffect(() => {
-        if (currentYPosition > window.innerHeight / 6) {
+        const viewportHeight = window.innerHeight;
+        const pageHeight = document.body.scrollHeight;
+        const scrollThreshold = viewportHeight / 6;
+        const bottomThreshold = pageHeight - viewportHeight - scrollThreshold;
+
+        if (currentYPosition > scrollThreshold && currentYPosition < bottomThreshold) {
             setShowButton(true);
         } else {
             setShowButton(false);

--- a/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.tsx
+++ b/frontend-next-migration/src/features/ScrollTop/ui/v2/ScrollTop.tsx
@@ -7,6 +7,15 @@ import { useCurrentYPosition } from '@/shared/lib/hooks';
 import upUpIcon from '@/shared/assets/icons/UpUp arrows.svg';
 import cls from './ScrollTop.module.scss';
 
+/**
+ * Checks whether the user's current Y position is between scrollThreshold and bottomThreshold.
+ * If it is, shows the button, otherwise hides it.
+ *
+ * @param {number} currentYPosition - The user's current Y-position.
+ * @param {number} scrollThreshold - The threshold value above which the button is displayed.
+ * @param {number} bottomThreshold - The threshold below which the button is hidden.
+ */
+
 interface ScrollTopProps {
     className?: string;
 }


### PR DESCRIPTION
## 📄 **Pull Request Overview**

closes 400
## 🔧 **Changes Made**

Fixed a bug with the ScrollTop button overlay the feedback button on HD screen.
Added a feature where the ScrollTop button is hidden in the footer. This fixes the problem where the ScrollTop button covers the feedback form.
Updated tests to reflect functionality.

---

## ✅ **Checklist Before Submission**

-  I have tested my code, and it works as expected.
- I have added or updated JSDoc comments for all relevant code.
- Added new tests or updated existing ones for the changes made.

---

## 📝 **Additional Information**

New ScrollTop button location on HD display:
![hd-overlay](https://github.com/user-attachments/assets/d5257cdc-e0c6-4790-8e40-b772e41d4239)

Example of hiding ScrollTop at the bottom of the page:

https://github.com/user-attachments/assets/89cd2585-3b10-4e8e-b455-33b231bad054

