### PR TITLE
Juhaj77/enhancement/474 defense gallery new card component for mobile

### DIFF
--- a/frontend-next-migration/src/app/[lng]/(helper)/admin/page.tsx
+++ b/frontend-next-migration/src/app/[lng]/(helper)/admin/page.tsx
@@ -7,6 +7,7 @@ import jokester from '@/shared/assets/images/heros/jokester/Jokester.png';
 import sleeper from '@/shared/assets/images/heros/sleeper/Sleeper_new.png';
 import fatePriest from '@/shared/assets/images/heros/fate-priest/fate-priest.png';
 import mirror from '@/shared/assets/images/heros/mirror/Mirror.png';
+import { useRef } from 'react';
 import {
     NavMenuWithDropdowns,
     NavMenuWithDropdownsProps,
@@ -20,8 +21,7 @@ import { ThemeSwitcher } from '@/features/ThemeSwitcher';
 import { DescriptionCard, DescriptionCardTheme } from '@/shared/ui/v2/DescriptionCard';
 import defenceGallery from '@/shared/assets/images/descriptionCard/defense_gallery.png';
 import retroflector from '@/shared/assets/images/descriptionCard/retroflector.png';
-import cls from '@/shared/ui/v2/ModularCard/ui/ModularCard.module.scss';
-
+import { MobileCard, MobileCardTheme } from '@/shared/ui/v2/MobileCard';
 
 const Page = () => {
     const navMenuWithDropdownsProps2: NavMenuWithDropdownsProps = {
@@ -90,8 +90,21 @@ const Page = () => {
             },
         ],
     };
+    const cardRef = useRef<HTMLDivElement>(null);
 
     const { t } = useClientTranslation('admin');
+    const componentsArray = Array(9).fill(null);
+    const handleFocusAndScroll = () => {
+        if (cardRef.current) {
+            cardRef.current.focus(); // Fokusoi elementtiin ensin
+            cardRef.current.scrollIntoView({
+                behavior: 'smooth', // Rullausanimaatio voi olla 'auto' tai 'smooth'
+                block: 'start', // Elementin pystysuuntainen sijainti — alku
+                inline: 'nearest', // Elementin vaakasuuntainen sijainti
+            });
+        }
+    };
+
     return (
         <LayoutWithSidebars
             // rightSidebar={di}
@@ -114,6 +127,19 @@ const Page = () => {
             // }}
         >
             {/* Testing ModularCard */}
+            <button
+                style={{
+                    paddingLeft: '1em',
+                    paddingRight: '1em',
+                    border: '1px solid black',
+                    borderRadius: '10px',
+                    cursor: 'pointer',
+                    backgroundColor: 'lightblue',
+                }}
+                onClick={handleFocusAndScroll}
+            >
+                focus testing button
+            </button>
             <h2>Testing Defense Gallery ModularCard</h2>
             <div
                 style={{
@@ -390,6 +416,54 @@ const Page = () => {
                     />
                 </DescriptionCard.Image>
             </DescriptionCard>
+            <div
+                style={{
+                    display: 'flex',
+                    gap: '.5em',
+                    flexWrap: 'wrap',
+                    justifyContent: 'center',
+                    marginTop: '.5em',
+                }}
+            >
+                {componentsArray.map((_, index) => {
+                    if (index === 0)
+                        return (
+                            <MobileCard
+                                ref={cardRef}
+                                path="/hero-development"
+                                withScalableLink={true}
+                                key={index}
+                                theme={MobileCardTheme.DEFENSEGALLERY}
+                            >
+                                <MobileCard.Texts
+                                    title1="Mikälie"
+                                    title2="Tämäonpitkänimi"
+                                />
+                                <MobileCard.Image
+                                    backgroundColor="yellow"
+                                    src={jokester}
+                                    alt="Jåker"
+                                />
+                            </MobileCard>
+                        );
+                    return (
+                        <MobileCard
+                            key={index}
+                            theme={MobileCardTheme.DEFENSEGALLERY}
+                        >
+                            <MobileCard.Texts
+                                title1="Torjujat"
+                                title2="Ahmatti"
+                            />
+                            <MobileCard.Image
+                                backgroundColor="#FF0000"
+                                src={hannu}
+                                alt="hannu hodari"
+                            />
+                        </MobileCard>
+                    );
+                })}
+            </div>
         </LayoutWithSidebars>
     );
 };

--- a/frontend-next-migration/src/shared/ui/v2/MobileCard/index.ts
+++ b/frontend-next-migration/src/shared/ui/v2/MobileCard/index.ts
@@ -1,0 +1,1 @@
+export { default as MobileCard, MobileCardTheme } from './ui/MobileCard';

--- a/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.module.scss
@@ -1,0 +1,65 @@
+@mixin card-dimensions {
+  --gap: 0.5em;
+  width: calc(33.33% - var(--gap));
+  height: calc(33.33vh - var(--gap));
+}
+
+.MobileCard.DefenseGalleryCard  {
+  @include card-dimensions;
+  overflow: hidden;
+  border-radius: var(--border-radius-md);
+  background-color: var(--base-card-background);
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  text-align: center;
+  border: var(--border-mobile) solid var(--black);
+
+}
+.withScalableLink {
+  .TextContainer {
+    transition: all ease;
+    transition-duration: .4s;
+  }
+  .ImageContainer{
+    transition: all ease-in-out;
+    transition-duration: .4s;
+  }
+  &:hover {
+    .TextContainer {
+      height: 40% !important;
+    }
+    .ImageContainer {
+      height: 60% !important;
+    }
+  }
+}
+.AppLink {
+  @include card-dimensions;
+}
+
+.MobileCard.DefenseGalleryCard > .ImageContainer {
+  height: 70%;
+  width: 100%;
+  overflow: hidden;
+  clip-path: polygon(0 20%, 100% 0, 100% 100%, 0 100%);
+  padding-top: 20%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.MobileCard.DefenseGalleryCard > .TextContainer {
+  margin-top: 10%;
+}
+.MobileCard.DefenseGalleryCard > .TextContainer > .Title1 {
+  font-family: var(--font-family-title);
+  font-size: 1.5rem;
+  font-weight: 400;
+}
+.MobileCard.DefenseGalleryCard > .TextContainer > .Title2 {
+  color:var(--primary-color);
+  font-family: var(--font-family-title);
+  font-size: 1.5rem;
+  font-weight: 400;
+}
+

--- a/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.module.scss
+++ b/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.module.scss
@@ -7,14 +7,14 @@
 .MobileCard.DefenseGalleryCard  {
   @include card-dimensions;
   overflow: hidden;
-  border-radius: var(--border-radius-md);
+  border-radius: var(--corner-radius-web);
   background-color: var(--base-card-background);
   display: flex;
   flex-direction: column;
   justify-content: space-between;
   text-align: center;
   border: var(--border-mobile) solid var(--black);
-
+  box-shadow: var(--black) 4px 6px 0;
 }
 .withScalableLink {
   .TextContainer {

--- a/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.tsx
+++ b/frontend-next-migration/src/shared/ui/v2/MobileCard/ui/MobileCard.tsx
@@ -1,0 +1,203 @@
+import {
+    memo,
+    ReactNode,
+    forwardRef,
+    LegacyRef,
+    HTMLAttributes,
+    DetailedHTMLProps,
+    ForwardRefExoticComponent,
+    RefAttributes,
+} from 'react';
+import Image, { StaticImageData } from 'next/image';
+import cls from './MobileCard.module.scss';
+import { classNames } from '@/shared/lib/classNames/classNames';
+import { AppLink } from '@/shared/ui/AppLink/AppLink';
+
+/**
+ * Module containing a React CardTheme component with customizable themes, sizes, and square styling. (PRIMARY, DEFENSEGALLERY)
+ * @module MobileCard
+ */
+export enum MobileCardTheme {
+    PRIMARY = '',
+    DEFENSEGALLERY = 'DefenseGalleryCard',
+}
+
+/**
+ * Props for the ModularCard component. Extends HTMLDivElement attributes.
+ * {Object} ModularCardProps
+ * @property {string} [className=""] - Additional class name(s) for the Card.
+ * @property {theme} [theme=MobileCardTheme.PRIMARY] - Theme for the Card.
+ * @property {string} [path] - Link address (optional).
+ * @property {string} [isExternal=false] - If path is not in this server (optional).
+ * @property {string} [withScalableLink] - Additional styling to link (optional).
+ * @property {LegacyRef<HTMLDivElement>} [ref] - Reference to the card (optional)
+ * @property {ReactNode} children - The content of the Card.
+ */
+interface MobileCardProps
+    extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+    theme?: MobileCardTheme;
+    className?: string;
+    children: ReactNode;
+    path?: string;
+    isExternal?: boolean;
+    withScalableLink?: boolean;
+    ref?: LegacyRef<HTMLDivElement>;
+}
+
+interface MobileCardTextsProps {
+    className?: string;
+    title1: string;
+    title2: string;
+    children?: ReactNode;
+}
+
+interface MobileCardImageSectionProps {
+    className?: string;
+    alt: string;
+    src: StaticImageData | string;
+    backgroundColor?: string;
+}
+
+interface MobileCardComponent
+    extends ForwardRefExoticComponent<
+        Omit<MobileCardProps, 'ref'> & RefAttributes<HTMLDivElement>
+    > {
+    Texts: MobileCardTextsProps;
+    Image: MobileCardImageSectionProps;
+}
+
+const MobileCardBase: any = forwardRef<HTMLDivElement, MobileCardProps>(
+    (props: MobileCardProps, ref): JSX.Element => {
+        const {
+            path,
+            isExternal = false,
+            withScalableLink = false,
+            className = '',
+            children,
+            theme = MobileCardTheme.PRIMARY,
+        } = props;
+        const mods: Record<string, boolean> = {
+            [cls.withScalableLink]: withScalableLink,
+        };
+        if (path) {
+            return (
+                <AppLink
+                    to={path}
+                    isExternal={isExternal}
+                    className={cls.AppLink}
+                >
+                    <div
+                        ref={ref}
+                        tabIndex={0}
+                        style={{ width: '100%' }}
+                        className={classNames(cls.MobileCard, mods, [className, cls[theme]])}
+                    >
+                        {children}
+                    </div>
+                </AppLink>
+            );
+        }
+        return (
+            <div
+                ref={ref}
+                tabIndex={0}
+                className={classNames(cls.MobileCard, undefined, [className, cls[theme]])}
+            >
+                {children}
+            </div>
+        );
+    },
+);
+MobileCardBase.displayName = 'MobileCard';
+/**
+ * A memoized functional component that renders a mobile card with a title, text, and optional children.
+ * This component is useful for displaying structured information in a card-like layout for mobile views.
+ *
+ * @typedef {Object} MobileCardTextsProps
+ * @property {string} title1 - The title of the card (group). Defaults to an empty string if not provided.
+ * @property {string} title2 - The second title of the card (name). Defaults to an empty string if not provided.
+ * @property {React.ReactNode} [children] - Optional additional content to be rendered inside the card.
+ *
+ * @component
+ * @param {MobileCardTextsProps} props - The properties to customize the component.
+ * @returns {JSX.Element} A React component rendering a mobile card.
+ */
+const MobileCardTexts = memo(
+    ({ title1 = '', title2 = '', children }: MobileCardTextsProps): JSX.Element => {
+        return (
+            <div className={cls.TextContainer}>
+                <h2 className={cls.Title1}>{title1}</h2>
+                <p className={cls.Title2}>{title2}</p>
+                {children}
+            </div>
+        );
+    },
+);
+MobileCardTexts.displayName = 'MobileCard-Texts';
+/**
+ * MobileCardImageSection is a React functional component that displays an
+ * image within an image container. The container's background color can
+ * be customized using the `backgroundColor` prop. This component is memoized
+ * to optimize rendering performance.
+ *
+ * @param {Object} props - The properties object for the MobileCardImageSection component.
+ * @param {string} [props.className] - Optional CSS class name for additional styling.
+ * @param {string} props.alt - Alternate text for the image, used for accessibility.
+ * @param {string} props.backgroundColor - Background color for the container.
+ * @param {string} props.src - Source URL of the image to be displayed.
+ * @returns {JSX.Element} The rendered MobileCardImageSection component.
+ */
+const MobileCardImageSection = memo(
+    ({ className = '', alt, backgroundColor, src }: MobileCardImageSectionProps): JSX.Element => {
+        return (
+            <div
+                className={classNames(cls.ImageContainer, undefined, [className])}
+                style={{ backgroundColor }}
+            >
+                <Image
+                    src={src}
+                    alt={alt}
+                />
+            </div>
+        );
+    },
+);
+MobileCardImageSection.displayName = 'MobileCard-Image-Section';
+MobileCardBase.Texts = MobileCardTexts;
+MobileCardBase.Image = MobileCardImageSection;
+/**
+ * Card component with composable subcomponents.
+ * @example
+ *                            <MobileCard
+ *                                 path='/hero-development'
+ *                                 withScalableLink={true}
+ *                                 key={index}
+ *                                 theme={MobileCardTheme.DEFENSEGALLERY}>
+ *                                 <MobileCard.Texts
+ *                                     title1="Mikälie"
+ *                                     title2="Tämäonpitkänimi"
+ *                                />
+ *                                 <MobileCard.Image
+ *                                     backgroundColor="yellow"
+ *                                     src={jokester}
+ *                                     alt="Jåker"
+ *                                 />
+ *                             </MobileCard>
+ * @example
+ *                        <MobileCard
+ *                             key={index}
+ *                             theme={MobileCardTheme.DEFENSEGALLERY}
+ *                         >
+ *                             <MobileCard.Texts
+ *                                 title1="Torjujat"
+ *                                 title2="Ahmatti"
+ *                             />
+ *                             <MobileCard.Image
+ *                                 backgroundColor="#FF0000"
+ *                                 src={hannu}
+ *                                 alt="hannu hodari"
+ *                             />
+ *                         </MobileCard>
+ */
+const MobileCard: MobileCardComponent = MobileCardBase;
+export default MobileCard;


### PR DESCRIPTION
## 📄 **Pull Request Overview**
Added a new component `MobileCard` and a theme `DefenseGalleryGard` for it. The card is designed to fit 3 in a row and stack up to 3 vertically. The card also supports a link, and its animation can be enabled by passing `withScalableLink={true}`, causing the card's ImageSection to slightly shift. If the cards are used inside a container like `<div style={{ display: 'flex', flexWrap: 'wrap', gap: '0.5em' }}>...</div>`, it's important to update `--gap: 0.5em` in `MobileCard.module.css` accordingly. This allows 3 cards to fit side by side.
Closes [#474]



---



---

## 📝 **Additional Information**


![defenseCard](https://github.com/user-attachments/assets/98072f7d-0e7c-472e-a8fa-a3f4a3a9d988)
