### PR TITLE
Liemng/feature/490 category based filtering and infinite scroll on news page

### DIFF
--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/_getPage.ts
@@ -1,0 +1,15 @@
+import { createPage } from '@/app/_helpers';
+import { useServerTranslation } from '@/shared/i18n';
+
+export async function _getPage(lng: string) {
+    const { t } = await useServerTranslation(lng, 'news');
+    return createPage({
+        buildPage: () => ({}),
+        buildSeo: () => ({
+            title: t('head-title'),
+            description: t('head-description'),
+            keywords: t('head-keywords'),
+        }),
+    });
+}
+// This file is used to generate the page data for the news category page.

--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/_getPage.ts
@@ -1,8 +1,13 @@
 import { createPage } from '@/app/_helpers';
+import { slugToCategoryNameMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
 import { useServerTranslation } from '@/shared/i18n';
+import { notFound } from 'next/navigation';
 
-export async function _getPage(lng: string) {
+export async function _getPage(lng: string, slug: string) {
     const { t } = await useServerTranslation(lng, 'news');
+    if (!slug || !slugToCategoryNameMap[slug]) {
+        return notFound();
+    }
     return createPage({
         buildPage: () => ({}),
         buildSeo: () => ({

--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/not-found.tsx
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/not-found.tsx
@@ -1,0 +1,19 @@
+'use client';
+import { useClientTranslation } from '@/shared/i18n';
+
+export default function NotFound() {
+    const { t } = useClientTranslation('news');
+
+    return (
+        <div
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '240px',
+            }}
+        >
+            <h2>{t('not-found-category-title')}</h2>
+        </div>
+    );
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/page.tsx
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/[slug]/page.tsx
@@ -1,0 +1,6 @@
+import { withMetadataGenerator, withPageData } from '@/app/_helpers';
+import { _getPage } from './_getPage';
+import { NewsPage } from '@/preparedPages/NewsPages';
+
+export const generateMetadata = withMetadataGenerator(_getPage);
+export default withPageData(NewsPage, _getPage);

--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/not-found.tsx
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/not-found.tsx
@@ -1,0 +1,18 @@
+'use client';
+import { useClientTranslation } from '@/shared/i18n';
+
+export default function NotFound() {
+    const { t } = useClientTranslation('news');
+    return (
+        <div
+            style={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+                height: '240px',
+            }}
+        >
+            <h2>{t('page-not-found')}</h2>
+        </div>
+    );
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/news/category/page.tsx
+++ b/frontend-next-migration/src/app/[lng]/(helper)/news/category/page.tsx
@@ -1,0 +1,6 @@
+'use client';
+import { notFound } from 'next/navigation';
+
+export default function CategoryPage() {
+    notFound();
+}

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -239,6 +239,17 @@ export const newsApi = directusApi.injectEndpoints({
                 return { data: newsCategories };
             },
         }),
+        /**
+         * Fetches the total count of published news items. Optionally filters by category slug.
+         *
+         * If no category slug is provided, it returns the total count of all published news items.
+         * If a category slug is provided, it converts the slug to a category name and returns the count
+         * of published news items in that category.
+         *
+         * @query
+         * @param {string} [categorySlug] - The slug of the category to filter news items by. If not provided, counts all published news items.
+         * @returns {Promise<Object>} The total count of news items.
+         */
         getTotalNewsCount: builder.query<number, string>({
             queryFn: async (categorySlug?: string) => {
                 try {
@@ -259,7 +270,6 @@ export const newsApi = directusApi.injectEndpoints({
                                 error: { status: 404, data: 'No news count found' },
                             };
                         }
-                        // console.log('total news count', totalNewsCount[0].count);
                         return {
                             data: Number(totalNewsCount[0].count),
                             error: undefined,
@@ -298,7 +308,6 @@ export const newsApi = directusApi.injectEndpoints({
                         error: undefined,
                     };
                 } catch (error) {
-                    console.error('Total news counr fetch error:', error);
                     return {
                         data: undefined,
                         error: { status: 500, data: 'Internal server error' },

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -2,6 +2,7 @@ import { categoryNameToSlugMap } from '@/features/NavigateNewsPage/ui/NewsPageNa
 import { directusApi } from '@/shared/api'; // Ensure the base Directus API setup is correct.
 import { envHelper } from '@/shared/const/envHelper';
 import { createDirectus, rest, readItems, readItem } from '@directus/sdk';
+import { News } from '../model/types/types';
 
 const directusBaseUrl = envHelper.directusHost;
 const client = createDirectus(directusBaseUrl).with(rest());
@@ -28,9 +29,9 @@ export const newsApi = directusApi.injectEndpoints({
          * @returns {Promise<Object>} The data containing the fetched news items.
          * @property {Array} data - An array of news items with their associated details.
          */
-        getNews: builder.query({
+        getNews: builder.query<News[], number>({
             queryFn: async (_arg: number) => {
-                const newsItems = await client.request(
+                const newsItems = await client.request<News[]>(
                     readItems('news', {
                         fields: [
                             '*',
@@ -177,7 +178,7 @@ export const newsApi = directusApi.injectEndpoints({
                 return { data: newsCategories };
             },
         }),
-        getNewsByCategorySlug: builder.query({
+        getNewsByCategorySlug: builder.query<News[], string>({
             queryFn: async (_arg: string) => {
                 const categoryNames = Object.keys(categoryNameToSlugMap);
                 const categoryName = categoryNames.find(
@@ -192,7 +193,7 @@ export const newsApi = directusApi.injectEndpoints({
                     };
                 }
                 try {
-                    const newsByCategorySlug = await client.request(
+                    const newsByCategorySlug = await client.request<News[]>(
                         readItems('news', {
                             fields: [
                                 '*',

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -259,8 +259,9 @@ export const newsApi = directusApi.injectEndpoints({
                             error: { status: 404, data: 'No news count found' },
                         };
                     }
+                    // console.log('total news count', totalNewsCount[0].count);
                     return {
-                        data: totalNewsCount[0].count as unknown as number,
+                        data: Number(totalNewsCount[0].count) as number,
                         error: undefined,
                     };
                 } catch (error) {

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -1,8 +1,8 @@
-import { categoryNameToSlugMap } from '@/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown';
 import { directusApi } from '@/shared/api'; // Ensure the base Directus API setup is correct.
 import { envHelper } from '@/shared/const/envHelper';
 import { createDirectus, rest, readItems, readItem, aggregate } from '@directus/sdk';
 import { News } from '../model/types/types';
+import { categoryNameToSlugMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
 
 const directusBaseUrl = envHelper.directusHost;
 const client = createDirectus(directusBaseUrl).with(rest());

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -29,13 +29,17 @@ const slugToCategoryNameMap = Object.fromEntries(
 export const newsApi = directusApi.injectEndpoints({
     endpoints: (builder) => ({
         /**
-         * Fetches the list of published news items along with their associated data.
+         * Fetches the list of published news items along with their associated data. Optionally filters by category slug.
          *
          * The query includes news content, related category data, translation information, and images (e.g.,
          * titlePicture, extra pictures). The filter ensures that only news items with a status of 'published'
          * are retrieved. Results are sorted by the `date` field in descending order to show the latest news first.
          *
          * @query
+         * @param {Object} args - The arguments for the query.
+         * @param {number} args.limit - The maximum number of news items to fetch.
+         * @param {number} [args.page] - The page number for pagination.
+         * @param {string} [args.categorySlug] - The slug of the category to filter news items by. If not provided, all published news items are fetched.
          * @returns {Promise<Object>} The data containing the fetched news items.
          * @property {Array} data - An array of news items with their associated details.
          */
@@ -67,7 +71,7 @@ export const newsApi = directusApi.injectEndpoints({
                                 },
                                 sort: ['-date', '-id'],
                                 limit: safeLimit,
-                                page,
+                                page: page || 1,
                             }),
                         );
                         return { data: newsItems };
@@ -111,7 +115,6 @@ export const newsApi = directusApi.injectEndpoints({
                         meta: undefined,
                     };
                 } catch (error) {
-                    console.error('News fetch error:', error);
                     return {
                         data: undefined,
                         error: { status: 500, data: 'Internal server error' },
@@ -213,7 +216,7 @@ export const newsApi = directusApi.injectEndpoints({
                 } catch (error) {
                     return {
                         data: undefined,
-                        error: undefined,
+                        error: { status: 500, data: 'Internal server error' },
                         meta: undefined,
                     };
                 }

--- a/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
+++ b/frontend-next-migration/src/entities/NewsV2/Api/newsApi.ts
@@ -2,7 +2,7 @@ import { directusApi } from '@/shared/api'; // Ensure the base Directus API setu
 import { envHelper } from '@/shared/const/envHelper';
 import { createDirectus, rest, readItems, readItem, aggregate } from '@directus/sdk';
 import { News } from '../model/types/types';
-import { categoryNameToSlugMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
+import { slugToCategoryNameMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
 
 const directusBaseUrl = envHelper.directusHost;
 const client = createDirectus(directusBaseUrl).with(rest());
@@ -12,10 +12,6 @@ type GetNewsArgs = {
     page?: number | undefined;
     categorySlug?: string | undefined;
 };
-
-const slugToCategoryNameMap = Object.fromEntries(
-    Object.entries(categoryNameToSlugMap).map(([name, slug]) => [slug, name]),
-);
 
 /**
  * API service for interacting with the Directus backend to fetch news and news categories.

--- a/frontend-next-migration/src/entities/NewsV2/model/data/formatNews.ts
+++ b/frontend-next-migration/src/entities/NewsV2/model/data/formatNews.ts
@@ -1,6 +1,7 @@
 'use client';
+import { News } from '@/entities/NewsV2/model/types/types';
 
-export function formatNews(newsArray: any[] = [], lngCode: string) {
+export function formatNews(newsArray: News[] = [], lngCode: string) {
     return newsArray.map((newsItem) => {
         const translation = newsItem.translations.find((t: any) => t.languages_code === lngCode);
 

--- a/frontend-next-migration/src/entities/NewsV2/model/newsCategorySlugMap.ts
+++ b/frontend-next-migration/src/entities/NewsV2/model/newsCategorySlugMap.ts
@@ -6,3 +6,7 @@ export const categoryNameToSlugMap: Record<string, string> = {
     Announcement: NewsCategorySlug.ANNOUNCEMENT,
     'Game Update': NewsCategorySlug.GAME_UPDATE,
 };
+
+export const slugToCategoryNameMap = Object.fromEntries(
+    Object.entries(categoryNameToSlugMap).map(([name, slug]) => [slug, name]),
+);

--- a/frontend-next-migration/src/entities/NewsV2/model/newsCategorySlugMap.ts
+++ b/frontend-next-migration/src/entities/NewsV2/model/newsCategorySlugMap.ts
@@ -1,0 +1,8 @@
+import { NewsCategorySlug } from '@/entities/NewsV2/model/types/types';
+
+// map english name to slug
+export const categoryNameToSlugMap: Record<string, string> = {
+    Update: NewsCategorySlug.UPDATE,
+    Announcement: NewsCategorySlug.ANNOUNCEMENT,
+    'Game Update': NewsCategorySlug.GAME_UPDATE,
+};

--- a/frontend-next-migration/src/entities/NewsV2/model/types/types.ts
+++ b/frontend-next-migration/src/entities/NewsV2/model/types/types.ts
@@ -69,3 +69,9 @@ export interface MediaFile {
     tus_data: string | null;
     uploaded_on: string;
 }
+
+export enum NewsCategorySlug {
+    UPDATE = 'update',
+    ANNOUNCEMENT = 'announcement',
+    GAME_UPDATE = 'game-update',
+}

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
@@ -7,9 +7,6 @@
         
     }
     font-family: var(--font-family-secondary);
-    font-size: var(--font-size-l);
-    line-height: var(--font-line-l);
-    color: var(--primary-color);
     a {
         letter-spacing: -0.04em;    
     }

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
@@ -1,14 +1,7 @@
 .NewsNavMenu {
-    width: 100%;
-    min-width: 250px;
     margin-top: 100px;
     @media (max-width: breakpoint(md)) {
         margin-top: 0;
-        
-    }
-    font-family: var(--font-family-secondary);
-    a {
-        letter-spacing: -0.04em;    
     }
 }
 

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.module.scss
@@ -1,4 +1,4 @@
-.Width {
+.NewsNavMenu {
     width: 100%;
     min-width: 250px;
     margin-top: 100px;
@@ -6,4 +6,15 @@
         margin-top: 0;
         
     }
+    font-family: var(--font-family-secondary);
+    font-size: var(--font-size-l);
+    line-height: var(--font-line-l);
+    color: var(--primary-color);
+    a {
+        letter-spacing: -0.04em;    
+    }
+}
+
+.NewsActive {
+    text-decoration: underline;
 }

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
@@ -7,12 +7,11 @@
  * - For desktop devices: Shows an expanded static menu
  *
  * @component
- * @param {object} props - Component properties
- * @param {string} [props.className] - Optional CSS class name for styling the container
+ * @returns {JSX.Element} The rendered navigation menu component.
  *
  * @example
  *
- * <NewsPageNavMenuAsDropdown className="custom-menu-class" />
+ * <NewsPageNavMenuAsDropdown/>
  */
 'use client';
 import React from 'react';
@@ -29,11 +28,7 @@ import { DropDownElementASTextOrLink } from '@/shared/ui/DropdownWrapper';
 import { getRouteNewsCategoryPage } from '@/shared/appLinks/RoutePaths';
 import { categoryNameToSlugMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
 
-interface NewsPageNavMenuAsDropdownProps {
-    className?: string;
-}
-
-const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ className }) => {
+const NewsPageNavMenuAsDropdown: React.FC = () => {
     const { isMobileSize, isTabletSize } = useSizes();
     const isTouchDevice = isMobileSize || isTabletSize;
     const { t } = useClientTranslation('news');

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
@@ -35,6 +35,13 @@ interface NewsPageNavMenuAsDropdownProps {
     className?: string;
 }
 
+// map english name to slug
+export const categoryNameToSlugMap: Record<string, string> = {
+    'Update': NewsCategorySlug.UPDATE,
+    'Announcement': NewsCategorySlug.ANNOUNCEMENT,
+    'Game Update': NewsCategorySlug.GAME_UPDATE,
+};
+
 const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ className }) => {
     const { isMobileSize, isTabletSize } = useSizes();
     const isTouchDevice = isMobileSize || isTabletSize;
@@ -44,13 +51,6 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
     const params = useParams();
     const lng = params.lng as string;
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
-
-    // map english name to slug
-    const categoryNameToSlugMap: Record<string, string> = {
-        'Update': NewsCategorySlug.UPDATE,
-        'Announcement': NewsCategorySlug.ANNOUNCEMENT,
-        'Game Update': NewsCategorySlug.GAME_UPDATE,
-    };
 
     // Extract categories with localized names and slugs
     const categories = data

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
@@ -29,6 +29,7 @@ import { useGetNewsCategoriesQuery } from '@/entities/NewsV2';
 import { useParams } from 'next/navigation';
 import { DropDownElementASTextOrLink } from '@/shared/ui/DropdownWrapper';
 import { NewsCategorySlug } from '@/entities/NewsV2/model/types/types';
+import { getRouteNewsCategoryPage } from '@/shared/appLinks/RoutePaths';
 
 interface NewsPageNavMenuAsDropdownProps {
     className?: string;
@@ -68,13 +69,14 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
             })
             .filter((item) => item.localizedName && item.slug)
         : [];
-
+    
     const dropdownItems: DropDownElementASTextOrLink[] = categories.map((category) => ({
-        elementText: category.localizedName,
+        elementText: category.localizedName.charAt(0).toUpperCase() + category.localizedName.slice(1),
         link: {
-            path: `/news/category/${category.slug}`,
+            path: getRouteNewsCategoryPage(category.slug),
             isExternal: false
         },
+        active: params.slug === category.slug,
     }));
 
     const navMenuWithDropdownsMobileProps: NavMenuWithDropdownsProps = {
@@ -94,12 +96,14 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
         <div className={className}>
             {isTouchDevice ? (<nav>
                 <NavMenuWithDropdowns
-                    className={cls.Width}
+                    className={cls.WidthNewsNavMenu}
+                    customActiveClassName={cls.NewsActive}
                     {...navMenuWithDropdownsMobileProps}
                 />
             </nav>) : (<nav>
                 <NavMenuWithDropdowns
-                    className={cls.Width}
+                    className={cls.NewsNavMenu}
+                    customActiveClassName={cls.NewsActive}
                     {...navMenuWithDropdownsDesktopProps}
                 />
             </nav>)}

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
@@ -13,8 +13,6 @@
  * @example
  *
  * <NewsPageNavMenuAsDropdown className="custom-menu-class" />
- * @remarks
- * Currently using hard-coded categories as placeholders.
  */
 'use client';
 import React from 'react';
@@ -62,7 +60,6 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
             })
             .filter((item) => item.localizedName && item.slug)
         : [];
-    
     const dropdownItems: DropDownElementASTextOrLink[] = categories.map((category) => ({
         elementText: category.localizedName.charAt(0).toUpperCase() + category.localizedName.slice(1),
         link: {
@@ -71,7 +68,6 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
         },
         active: params.slug === category.slug,
     }));
-
     const navMenuWithDropdownsMobileProps: NavMenuWithDropdownsProps = {
         title: t('category-title'),
         openByDefault: false,
@@ -86,21 +82,23 @@ const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ c
     };
 
     return (
-        <div className={className}>
-            {isTouchDevice ? (<nav>
+        // Use a fragment to avoid unnecessary div wrapper
+        // eslint-disable-next-line react/jsx-no-useless-fragment
+        <>
+            {isTouchDevice ? (
                 <NavMenuWithDropdowns
                     className={cls.WidthNewsNavMenu}
                     customActiveClassName={cls.NewsActive}
                     {...navMenuWithDropdownsMobileProps}
                 />
-            </nav>) : (<nav>
+            ) : (
                 <NavMenuWithDropdowns
                     className={cls.NewsNavMenu}
                     customActiveClassName={cls.NewsActive}
                     {...navMenuWithDropdownsDesktopProps}
                 />
-            </nav>)}
-        </div>
+            )}
+        </>
     );
 };
 

--- a/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
+++ b/frontend-next-migration/src/features/NavigateNewsPage/ui/NewsPageNavMenuAsDropdown.tsx
@@ -28,19 +28,12 @@ import useSizes from '@/shared/lib/hooks/useSizes';
 import { useGetNewsCategoriesQuery } from '@/entities/NewsV2';
 import { useParams } from 'next/navigation';
 import { DropDownElementASTextOrLink } from '@/shared/ui/DropdownWrapper';
-import { NewsCategorySlug } from '@/entities/NewsV2/model/types/types';
 import { getRouteNewsCategoryPage } from '@/shared/appLinks/RoutePaths';
+import { categoryNameToSlugMap } from '@/entities/NewsV2/model/newsCategorySlugMap';
 
 interface NewsPageNavMenuAsDropdownProps {
     className?: string;
 }
-
-// map english name to slug
-export const categoryNameToSlugMap: Record<string, string> = {
-    'Update': NewsCategorySlug.UPDATE,
-    'Announcement': NewsCategorySlug.ANNOUNCEMENT,
-    'Game Update': NewsCategorySlug.GAME_UPDATE,
-};
 
 const NewsPageNavMenuAsDropdown: React.FC<NewsPageNavMenuAsDropdownProps> = ({ className }) => {
     const { isMobileSize, isTabletSize } = useSizes();

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsElementPage/ui/NewsElementPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsElementPage/ui/NewsElementPage.tsx
@@ -27,7 +27,7 @@ const NewsElementPage = () => {
     const lng = params.lng as string;
 
     const { t } = useClientTranslation('news');
-    const { data: moreNews } = useGetNewsQuery(2);
+    const { data: moreNews } = useGetNewsQuery({ limit: 2 });
     const { data, isLoading } = useGetNewsByIdQuery(id as string);
     const directusBaseUrl = envHelper.directusHost;
     const router = useRouter();

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
@@ -42,7 +42,6 @@ $touchSize: 1023px;
 
 .noMoreNews {
     margin: 20px 0;
-    padding-left: 8px;
     font-family: var(--font-family-secondary);
     font-size: var(-font-size-m);
     opacity: 0.7;

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
@@ -39,3 +39,11 @@ $touchSize: 1023px;
     grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
     justify-content: center;
 }
+
+.noMoreNews {
+    margin: 20px 0;
+    padding-left: 8px;
+    font-family: var(--font-family-secondary);
+    font-size: var(-font-size-m);
+    opacity: 0.8;
+}

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
@@ -46,4 +46,5 @@ $touchSize: 1023px;
     font-family: var(--font-family-secondary);
     font-size: var(-font-size-m);
     opacity: 0.7;
+    text-align: center;
 }

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.module.scss
@@ -45,5 +45,5 @@ $touchSize: 1023px;
     padding-left: 8px;
     font-family: var(--font-family-secondary);
     font-size: var(-font-size-m);
-    opacity: 0.8;
+    opacity: 0.7;
 }

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -6,6 +6,7 @@ import { useGetNewsQuery, formatNews } from '@/entities/NewsV2';
 import { useParams } from 'next/navigation';
 import { envHelper } from '@/shared/const/envHelper';
 import hannu from '@/shared/assets/images/heros/hannu-hodari/hannu-hodari.png';
+import { useGetNewsByCategorySlugQuery } from '@/entities/NewsV2/Api/newsApi';
 
 const NewsPage = () => {
     // later use this to fetch data from the backend
@@ -13,13 +14,18 @@ const NewsPage = () => {
     //     // setSearchValue(e.target.value);
     // };
 
-    const { data } = useGetNewsQuery(6);
+    const { data: news } = useGetNewsQuery(6);
     const params = useParams();
+    // console.log(params);
     const lng = params.lng as string;
+    const categorySlug = params.slug as string | undefined;
+    const { data: newsByCategory, error } = useGetNewsByCategorySlugQuery(categorySlug ?? '');
+    // console.log(newsByCategory);
+    // console.log(error);
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
-    const groupedNews = formatNews(data, lngCode || 'fi-FI');
+    const groupedNews = formatNews(news, lngCode || 'fi-FI');
 
     return (
         <main className={cls.NewsPage}>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -31,11 +31,10 @@ const NewsPage = () => {
     const { data: totalNewsCount } = useGetTotalNewsCountQuery();
     // console.log('🔄 NewsPage render', { currentPage, allNews, hasMoreNewsState });
 
-    const hasMoreNews = useMemo(() => {
-        if (typeof totalNewsCount !== 'number') {
-            return false;
+    useEffect(() => {
+        if (typeof totalNewsCount === 'number') {
+            setHasMoreNewsState(limit * currentPage < totalNewsCount);
         }
-        return limit * currentPage < totalNewsCount;
     }, [currentPage, totalNewsCount]);
 
     useEffect(() => {
@@ -45,15 +44,10 @@ const NewsPage = () => {
                 setHasMoreNewsState(false);
             }
             setAllNews((prevNews) => {
-                // console.log('news', news);
                 return currentPage === 1 ? news : [...prevNews, ...news];
             });
         }
     }, [news]);
-
-    useEffect(() => {
-        setHasMoreNewsState(hasMoreNews);
-    }, [currentPage, totalNewsCount]);
 
     const loadMoreNews = () => {
         if (hasMoreNewsState) {
@@ -114,12 +108,11 @@ const NewsPage = () => {
                             />
                         );
                     })}
-                    {hasMoreNewsState ? (
-                        <span ref={observerRef} />
-                    ) : (
-                        <div>There is no news left</div>
-                    )}
+                    {hasMoreNewsState && <span ref={observerRef} />}
                 </div>
+                {typeof totalNewsCount === 'number' && !hasMoreNewsState && (
+                    <div className={cls.noMoreNews}>No more news available</div>
+                )}
             </Container>
         </main>
     );

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -19,7 +19,7 @@ const NewsPage = () => {
 
     const params = useParams();
     const lng = params.lng as string;
-    const categorySlug = typeof params.slug === 'string' ? params.slug : undefined;
+    const currentSlug = typeof params.slug === 'string' ? params.slug : undefined;
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
@@ -30,8 +30,8 @@ const NewsPage = () => {
     const [isLoading, setIsLoading] = useState<boolean>(true);
 
     const { t } = useClientTranslation('news');
-    const { data: news } = useGetNewsQuery({ limit, page: currentPage, categorySlug });
-    const { data: totalNewsCount } = useGetTotalNewsCountQuery(categorySlug ?? '');
+    const { data: news } = useGetNewsQuery({ limit, page: currentPage, categorySlug: currentSlug });
+    const { data: totalNewsCount } = useGetTotalNewsCountQuery(currentSlug ?? '');
 
     useEffect(() => {
         if (typeof totalNewsCount === 'number') {
@@ -108,7 +108,7 @@ const NewsPage = () => {
                     })}
                     {hasMoreNewsState && <div ref={observeElementRef} />}
                 </div>
-                <div>{isLoading && 'Loading...'}</div>
+                <div>{isLoading && 'Loading... from news page'}</div>
                 {renderNoMoreNews()}
             </Container>
         </main>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -108,7 +108,7 @@ const NewsPage = () => {
                     })}
                     {hasMoreNewsState && <div ref={observeElementRef} />}
                 </div>
-                <div>{isLoading && 'Loading... from news page'}</div>
+                <div>{isLoading && 'Loading...'}</div>
                 {renderNoMoreNews()}
             </Container>
         </main>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -7,6 +7,9 @@ import { useParams } from 'next/navigation';
 import { envHelper } from '@/shared/const/envHelper';
 import hannu from '@/shared/assets/images/heros/hannu-hodari/hannu-hodari.png';
 import { useGetTotalNewsCountQuery } from '@/entities/NewsV2/Api/newsApi';
+import { useEffect, useRef, useState } from 'react';
+import { News } from '@/entities/NewsV2/model/types/types';
+import { current } from '@reduxjs/toolkit';
 
 const NewsPage = () => {
     // later use this to fetch data from the backend
@@ -17,23 +20,86 @@ const NewsPage = () => {
     const params = useParams();
     const lng = params.lng as string;
     const categorySlug = typeof params.slug === 'string' ? params.slug : undefined;
-    const page = 3;
-    const limit = 6;
-
-    const { data: news } = useGetNewsQuery({ limit, page, categorySlug });
-    const { data: totalNewsCount } = useGetTotalNewsCountQuery();
-    // console.log(totalNewsCount);
-
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
-    const hasMoreNews = () => {
-        const recievedCount = limit * page;
-        return recievedCount < (totalNewsCount ?? 0);
-    };
-    // console.log('has more news?,', hasMoreNews());
+    const limit = 6;
+    const [currentPage, setCurrentPage] = useState(1);
+    const [allNews, setAllNews] = useState<News[]>([]);
 
-    const groupedNews = formatNews(news, lngCode || 'fi-FI');
+    const { data: news } = useGetNewsQuery({ limit, page: currentPage, categorySlug });
+    const { data: totalNewsCount } = useGetTotalNewsCountQuery();
+
+    const hasMoreNews = () => {
+        const receivedCount = limit * currentPage;
+        if (typeof totalNewsCount !== 'number') return false;
+        return receivedCount < totalNewsCount;
+    };
+    const [hasMoreNewsState, setHasMoreNewsState] = useState(hasMoreNews());
+    // console.log(
+    //     'has more news',
+    //     hasMoreNews(),
+    //     'hasmorenews state',
+    //     hasMoreNewsState,
+    //     'totalnews count',
+    //     totalNewsCount,
+    //     'current page',
+    //     currentPage,
+    // );
+    useEffect(() => {
+        setHasMoreNewsState(hasMoreNews());
+    }, [currentPage, totalNewsCount]);
+
+    useEffect(() => {
+        if (news) {
+            setAllNews((prevNews) => {
+                return currentPage === 1 ? news : [...prevNews, ...news];
+            });
+        }
+    }, [news]);
+
+    const loadMoreNews = () => {
+        if (hasMoreNewsState) {
+            // console.log(allNews);
+            setCurrentPage((prev) => prev + 1);
+        }
+    };
+
+    useEffect(() => {
+        // console.log('page', currentPage);
+    }, [currentPage]);
+
+    const observeElem = useRef<HTMLSpanElement | null>(null);
+    const handleObserver = (entries: IntersectionObserverEntry[]) => {
+        // console.log(entries[0]);
+        if (entries[0].isIntersecting) {
+            // your logic here
+            loadMoreNews();
+        }
+    };
+    const observerOptions = {
+        threshold: 1,
+    };
+
+    useEffect(() => {
+        if (typeof window === 'undefined' || !window.IntersectionObserver) return;
+        if (!observeElem.current) {
+            return;
+        }
+        const observer = new IntersectionObserver(handleObserver, observerOptions);
+        if (observeElem.current) {
+            observer.observe(observeElem.current);
+        }
+
+        // clean up
+        return () => {
+            if (observeElem.current) {
+                observer.unobserve(observeElem.current);
+            }
+        };
+    }, [hasMoreNewsState]);
+
+    const groupedNews = formatNews(allNews, lngCode || 'fi-FI');
     // console.log(groupedNews);
 
     return (
@@ -55,6 +121,11 @@ const NewsPage = () => {
                             />
                         );
                     })}
+                    {hasMoreNewsState ? (
+                        <span ref={observeElem} />
+                    ) : (
+                        <div>There is no news left</div>
+                    )}
                 </div>
             </Container>
         </main>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -6,7 +6,6 @@ import { useGetNewsQuery, formatNews } from '@/entities/NewsV2';
 import { useParams } from 'next/navigation';
 import { envHelper } from '@/shared/const/envHelper';
 import hannu from '@/shared/assets/images/heros/hannu-hodari/hannu-hodari.png';
-import { useGetNewsByCategorySlugQuery } from '@/entities/NewsV2/Api/newsApi';
 
 const NewsPage = () => {
     // later use this to fetch data from the backend
@@ -18,14 +17,12 @@ const NewsPage = () => {
     const lng = params.lng as string;
     const categorySlug = params.slug as string | undefined;
 
-    const { data: news } = useGetNewsQuery(6);
-    const { data: newsByCategory } = useGetNewsByCategorySlugQuery(categorySlug ?? '');
+    const { data: news } = useGetNewsQuery({ limit: 6, categorySlug: categorySlug });
 
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
-    const newsData = newsByCategory ?? news;
-    const groupedNews = formatNews(newsData, lngCode || 'fi-FI');
+    const groupedNews = formatNews(news, lngCode || 'fi-FI');
 
     return (
         <main className={cls.NewsPage}>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -14,18 +14,18 @@ const NewsPage = () => {
     //     // setSearchValue(e.target.value);
     // };
 
-    const { data: news } = useGetNewsQuery(6);
     const params = useParams();
-    // console.log(params);
     const lng = params.lng as string;
     const categorySlug = params.slug as string | undefined;
-    const { data: newsByCategory, error } = useGetNewsByCategorySlugQuery(categorySlug ?? '');
-    // console.log(newsByCategory);
-    // console.log(error);
+
+    const { data: news } = useGetNewsQuery(6);
+    const { data: newsByCategory } = useGetNewsByCategorySlugQuery(categorySlug ?? '');
+
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
-    const groupedNews = formatNews(news, lngCode || 'fi-FI');
+    const newsData = newsByCategory ?? news;
+    const groupedNews = formatNews(newsData, lngCode || 'fi-FI');
 
     return (
         <main className={cls.NewsPage}>

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -7,7 +7,7 @@ import { useParams } from 'next/navigation';
 import { envHelper } from '@/shared/const/envHelper';
 import hannu from '@/shared/assets/images/heros/hannu-hodari/hannu-hodari.png';
 import { useGetTotalNewsCountQuery } from '@/entities/NewsV2/Api/newsApi';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { News } from '@/entities/NewsV2/model/types/types';
 
 const NewsPage = () => {
@@ -32,16 +32,15 @@ const NewsPage = () => {
     const { data: totalNewsCount } = useGetTotalNewsCountQuery(categorySlug ?? '');
     // console.log('🔄 NewsPage render', { currentPage, allNews, hasMoreNewsState, isLoading });
 
+    const isLoadingRef = useRef(isLoading);
+    useEffect(() => {
+        isLoadingRef.current = isLoading;
+    }, [isLoading]);
+
     useEffect(() => {
         if (typeof totalNewsCount === 'number') {
             setHasMoreNewsState(limit * currentPage < totalNewsCount);
         }
-        // console.log(
-        //     'current Page/total news changed',
-        //     currentPage,
-        //     totalNewsCount,
-        //     hasMoreNewsState,
-        // );
     }, [currentPage, totalNewsCount]);
 
     useEffect(() => {
@@ -56,7 +55,6 @@ const NewsPage = () => {
             setIsLoading(false);
             // console.log('isLoading', isLoading);
         }
-        // console.log('isLoading', isLoading);
     }, [news]);
     useEffect(() => {
         // console.log('isLoading changed:', isLoading);
@@ -73,11 +71,20 @@ const NewsPage = () => {
     const observerRef = useRef<HTMLSpanElement | null>(null);
     const handleObserver = (entries: IntersectionObserverEntry[]) => {
         // console.log('🔍 Observer fired', entries[0]);
-        // console.log('isLoading', isLoading);
         // console.log(
-        //     entries[0].isIntersecting && !isLoading && hasMoreNewsState && allNews.length > 0,
+        //     'is intersecting',
+        //     entries[0].isIntersecting,
+        //     'isLoading',
+        //     !isLoading,
+        //     'isLoadingRef',
+        //     !isLoadingRef.current,
+        //     'hasMoreNewsState',
+        //     hasMoreNewsState,
+        //     'allNews.length',
+        //     allNews.length > 0,
         // );
-        if (entries[0].isIntersecting && !isLoading && hasMoreNewsState && allNews.length > 0) {
+        // console.log(entries[0].isIntersecting && !isLoadingRef.current && hasMoreNewsState);
+        if (entries[0].isIntersecting && !isLoadingRef.current && hasMoreNewsState) {
             loadMoreNews();
         }
     };

--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsPage.tsx
@@ -6,6 +6,7 @@ import { useGetNewsQuery, formatNews } from '@/entities/NewsV2';
 import { useParams } from 'next/navigation';
 import { envHelper } from '@/shared/const/envHelper';
 import hannu from '@/shared/assets/images/heros/hannu-hodari/hannu-hodari.png';
+import { useGetTotalNewsCountQuery } from '@/entities/NewsV2/Api/newsApi';
 
 const NewsPage = () => {
     // later use this to fetch data from the backend
@@ -15,14 +16,25 @@ const NewsPage = () => {
 
     const params = useParams();
     const lng = params.lng as string;
-    const categorySlug = params.slug as string | undefined;
+    const categorySlug = typeof params.slug === 'string' ? params.slug : undefined;
+    const page = 3;
+    const limit = 6;
 
-    const { data: news } = useGetNewsQuery({ limit: 6, categorySlug: categorySlug });
+    const { data: news } = useGetNewsQuery({ limit, page, categorySlug });
+    const { data: totalNewsCount } = useGetTotalNewsCountQuery();
+    // console.log(totalNewsCount);
 
     const lngCode = lng === 'en' ? 'en-US' : lng === 'fi' ? 'fi-FI' : lng;
     const directusBaseUrl = envHelper.directusHost;
 
+    const hasMoreNews = () => {
+        const recievedCount = limit * page;
+        return recievedCount < (totalNewsCount ?? 0);
+    };
+    // console.log('has more news?,', hasMoreNews());
+
     const groupedNews = formatNews(news, lngCode || 'fi-FI');
+    // console.log(groupedNews);
 
     return (
         <main className={cls.NewsPage}>

--- a/frontend-next-migration/src/shared/appLinks/RoutePaths.ts
+++ b/frontend-next-migration/src/shared/appLinks/RoutePaths.ts
@@ -105,6 +105,7 @@ export const getRouteSessionExpiredPage = () => '/auth/sessionExpired';
 
 export const getRouteAllNewsPage = () => '/news';
 export const getRouteOneNewsPage = (id: string) => `/news/${id}`;
+export const getRouteNewsCategoryPage = (slug: string) => `/news/category/${slug}`;
 
 export const getRouteAllHeroesPage = () => '/heroes';
 export const getRouteOneHeroPage = (slug: string) => `/heroes/${slug}`;

--- a/frontend-next-migration/src/shared/i18n/locales/en/news.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/news.json
@@ -6,5 +6,7 @@
   "category-title": "Category",
   "next-button": "Next",
   "previous-button": "Previous",
-  "no-more-news": "No more news available"
+  "no-more-news": "No more news available",
+  "not-found-category-title": "Category not found",
+  "page-not-found": "Page not found"
 }

--- a/frontend-next-migration/src/shared/i18n/locales/en/news.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/news.json
@@ -5,5 +5,6 @@
   "head-keywords": "altzone, news, community, comics, games",
   "category-title": "Category",
   "next-button": "Next",
-  "previous-button": "Previous"
+  "previous-button": "Previous",
+  "no-more-news": "No more news available"
 }

--- a/frontend-next-migration/src/shared/i18n/locales/fi/news.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/news.json
@@ -6,5 +6,7 @@
   "category-title": "Kategoriat",
   "next-button": "Seuraava",
   "previous-button": "Edellinen",
-  "no-more-news": "Kaikki uutiset on ladattu"
+  "no-more-news": "Kaikki uutiset on ladattu",
+  "not-found-category-title": "Kategoriaa ei löytynyt",
+  "page-not-found": "Sivua ei löytynyt"
 }

--- a/frontend-next-migration/src/shared/i18n/locales/fi/news.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/news.json
@@ -5,5 +5,6 @@
   "head-keywords": "altzone, uutiset, yhteisö, sarjakuvat, pelit",
   "category-title": "Kategoriat",
   "next-button": "Seuraava",
-  "previous-button": "Edellinen"
+  "previous-button": "Edellinen",
+  "no-more-news": "Kaikki uutiset on ladattu"
 }

--- a/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.tsx
+++ b/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.tsx
@@ -45,6 +45,7 @@ function isDropDownElementASTextOrLink(item: any): item is DropDownElementASText
  * @param {boolean} [props.staticDropdown=false] - Determines if the first dropdown element remains static and always open.
  * @param {boolean} [props.titleAsActive=false] - Uses the active dropdown item title as the main dropdown title if the item's link path matches the current router path.
  * @param {string} [props.className=''] - Additional CSS classes for styling the root container.
+ * @param {string} [props.customActiveClassName=''] - Custom class name to apply when an item is active. Only applies to `DropDownElementASTextOrLink` items.
  * @returns {JSX.Element} - The rendered `NavMenuWithDropdowns` component.
  *
  * @example

--- a/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.tsx
+++ b/frontend-next-migration/src/shared/ui/NavMenuWithDropdownsV2/ui/NavMenuWithDropdowns.tsx
@@ -22,6 +22,7 @@ export interface NavMenuWithDropdownsProps {
     staticDropdown?: boolean;
     title: string;
     className?: string;
+    customActiveClassName?: string;
 }
 
 function isDropdownItem(
@@ -102,6 +103,7 @@ function NavMenuWithDropdowns(props: NavMenuWithDropdownsProps): JSX.Element {
         openByDefault = false,
         staticDropdown = false,
         titleAsActive = false,
+        customActiveClassName = '',
     } = props;
 
     const [realPath, setRealPath] = useState('/');
@@ -150,7 +152,10 @@ function NavMenuWithDropdowns(props: NavMenuWithDropdownsProps): JSX.Element {
                             <AppLink
                                 isExternal={item.link.isExternal}
                                 to={item.link.path}
-                                className={classNames(cls.link, { [cls.active]: item.active })}
+                                className={classNames(cls.link, {
+                                    [cls.active]: item.active,
+                                    [customActiveClassName ?? '']: item.active,
+                                })}
                             >
                                 {item.elementText}
                             </AppLink>

--- a/frontend-next-migration/src/widgets/NewsCard/ui/NewsCard.tsx
+++ b/frontend-next-migration/src/widgets/NewsCard/ui/NewsCard.tsx
@@ -34,7 +34,6 @@ const NewsCard = (props: NewsCardProps) => {
                                 src={picture}
                                 alt={title}
                                 className={cls.image}
-                                layout="responsive"
                                 width={100}
                                 height={600}
                             />


### PR DESCRIPTION
## 📄 **Pull Request Overview**

Closes [#490 ]

## 🔧 **Changes Made**

- Implemented infinite scroll using IntersectionObserver to automatically load more news when scrolling.
- Displayed message ("No more news available") when all results are loaded (only shown if the result count exceeds one page).
- Updated NewsPageNavMenuAsDropdown.tsx to use the category’s English name as the slug.
- Added prop to NavMenuWithDropDowns for custom active styles of the selected category.

- Modified getNews to support pagination (limit & page) and accept an optional categorySlug to fetch news by category.
- Created a new totalNewsCount API to: return the total number of news items, or total number of news items count by categorySlug, if provided.

- Added custom not-found pages for /news/category and /news/category/[slug] routes.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.✅
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.✅
- **Debugging**: No `console.log()` or other debugging statements are left.✅
- **Clean Code**: Removed commented-out or unnecessary code.✅
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).✅

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: 
![image](https://github.com/user-attachments/assets/3ce3941a-3210-45b9-9f67-1b3d084f7654)

- **Dependencies**: No added dependencies.
