### PR TITLE
Patinen/feature/470 mobile navbar animation

### DIFF
--- a/frontend-next-migration/src/shared/ui/DropdownWrapper/ui/DropdownWrapper.module.scss
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapper/ui/DropdownWrapper.module.scss
@@ -12,6 +12,7 @@
     padding: 8px 0;
     transform-origin: top;
     opacity: 0;
+    max-height: 0;
     transform: translateY(-10px);
     transition:
         opacity 0.3s ease,
@@ -21,6 +22,7 @@
     &.open {
         opacity: 1;
         transform: translateY(0);
+        max-height: 400px;
     }
 
     &.opening {

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
@@ -11,8 +11,6 @@
     top: 0;
     left: 10px;
     right: 10px;
-    // transition:
-        // height 0.4s ease-out;
     
     @media (min-width: 550px) {
         margin-top: 50px;
@@ -29,13 +27,19 @@
 }
 
 .NavbarDropdown {
-    transition: transform 0.4s ease-out;
-    transform-origin: top;
     transform: scaleY(0);
+    transform-origin: top;
+    max-height: 0;
+    overflow: hidden;
+    transition: 
+        transform 0.4s ease,
+        max-height 0.4s ease;
+
 }
 .openDropdown {
     padding: 15px;
     transform: scaleY(1);
+    max-height: 260px;
 }
 
 .HamurgerBtn {

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
@@ -30,16 +30,16 @@
 .NavbarDropdown {
     transform: scaleY(0);
     transform-origin: top;
-    height: 0;
+    max-height: 0;
     transition: 
         transform 0.3s ease,
-        height 0.3s ease;
+        max-height 0.3s ease;
 
 }
 .openDropdown {
     padding: 15px;
     transform: scaleY(1);
-    height: 260px;
+    max-height: 400px;
 }
 
 .HamurgerBtn {
@@ -129,7 +129,8 @@
     transform: translateX(0) scaleX(1);
     transform-origin: right;
     transition:
-        transform 0.3s ease-out 0.2s,
-        opacity 0.3s ease-out 0.5s;
+        transform 0.3s ease-out,
+        opacity 0.3s ease-out;
     visibility: visible;
 }
+

--- a/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
+++ b/frontend-next-migration/src/widgets/Navbar/ui/NavbarMobileV2/NavbarMobile.module.scss
@@ -10,7 +10,8 @@
     box-shadow: 4px 4px black;
     top: 0;
     left: 10px;
-    right: 10px;
+    right: 10px;  
+
     
     @media (min-width: 550px) {
         margin-top: 50px;
@@ -29,17 +30,16 @@
 .NavbarDropdown {
     transform: scaleY(0);
     transform-origin: top;
-    max-height: 0;
-    overflow: hidden;
+    height: 0;
     transition: 
-        transform 0.4s ease,
-        max-height 0.4s ease;
+        transform 0.3s ease,
+        height 0.3s ease;
 
 }
 .openDropdown {
     padding: 15px;
     transform: scaleY(1);
-    max-height: 260px;
+    height: 260px;
 }
 
 .HamurgerBtn {


### PR DESCRIPTION
## 📄 **Pull Request Overview**

Closes #470 

## 🔧 **Changes Made**

1. Implemented smooth dropdown animation for mobile navbar container according to figma and desktop version.

2. Added `transform` and `height` transitions to `.NavbarDropdown`.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**:  No JS/TS logic added.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: All unnecessary test code and comments removed.
- **Tests**: Visual change only, no test coverage necessary. 
- **Documentation**: Not applicable

---

## 📝 **Additional Information**

- Container height fixed to 260px since the dropdown content is known and not scaling. 


https://github.com/user-attachments/assets/62bf8b45-bd7e-44ea-ad66-adb9578ce386

