### PR TITLE
Juhaj77/enhancement/519 reusable custom switch component for teacher pages

### DIFF
--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/_getPage.ts
@@ -1,13 +1,10 @@
 import { createPage } from '@/app/_helpers';
-import { TeachersPageProps } from '@/preparedPages/TeachersPage';
 import { useServerTranslation } from '@/shared/i18n';
 
 export async function _getPage(lng: string) {
     const { t } = await useServerTranslation(lng, 'teachers');
-    return createPage<TeachersPageProps>({
-        buildPage: () => ({
-            title: t('Teachers'),
-        }),
+    return createPage({
+        buildPage: () => ({}),
         buildSeo: () => ({
             title: t('head-title'),
             description: t('head-description'),

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/gaming/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/gaming/_getPage.ts
@@ -1,0 +1,14 @@
+import { createPage } from '@/app/_helpers';
+import { useServerTranslation } from '@/shared/i18n';
+
+export async function _getPage(lng: string) {
+    const { t } = await useServerTranslation(lng, 'teachers');
+    return createPage({
+        buildPage: () => ({}),
+        buildSeo: () => ({
+            title: t('head-title'),
+            description: t('head-description'),
+            keywords: t('head-keywords'),
+        }),
+    });
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/gaming/page.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/gaming/page.ts
@@ -1,0 +1,6 @@
+import { InstructionsPage } from '@/preparedPages/TeachersPage';
+import { withPageData, createMetadataGenerator } from '@/app/_helpers';
+import { _getPage } from './_getPage';
+
+export const generateMetadata = createMetadataGenerator(_getPage);
+export default withPageData(InstructionsPage, _getPage);

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/instructions/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/instructions/_getPage.ts
@@ -1,0 +1,14 @@
+import { createPage } from '@/app/_helpers';
+import { useServerTranslation } from '@/shared/i18n';
+
+export async function _getPage(lng: string) {
+    const { t } = await useServerTranslation(lng, 'teachers');
+    return createPage({
+        buildPage: () => ({}),
+        buildSeo: () => ({
+            title: t('head-title'),
+            description: t('head-description'),
+            keywords: t('head-keywords'),
+        }),
+    });
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/instructions/page.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/instructions/page.ts
@@ -1,0 +1,6 @@
+import { InstructionsPage } from '@/preparedPages/TeachersPage';
+import { withPageData, createMetadataGenerator } from '@/app/_helpers';
+import { _getPage } from './_getPage';
+
+export const generateMetadata = createMetadataGenerator(_getPage);
+export default withPageData(InstructionsPage, _getPage);

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/preparation/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/preparation/_getPage.ts
@@ -1,0 +1,14 @@
+import { createPage } from '@/app/_helpers';
+import { useServerTranslation } from '@/shared/i18n';
+
+export async function _getPage(lng: string) {
+    const { t } = await useServerTranslation(lng, 'teachers');
+    return createPage({
+        buildPage: () => ({}),
+        buildSeo: () => ({
+            title: t('head-title'),
+            description: t('head-description'),
+            keywords: t('head-keywords'),
+        }),
+    });
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/preparation/page.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/preparation/page.ts
@@ -1,0 +1,6 @@
+import { InstructionsPage } from '@/preparedPages/TeachersPage';
+import { withPageData, createMetadataGenerator } from '@/app/_helpers';
+import { _getPage } from './_getPage';
+
+export const generateMetadata = createMetadataGenerator(_getPage);
+export default withPageData(InstructionsPage, _getPage);

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/results/_getPage.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/results/_getPage.ts
@@ -1,0 +1,14 @@
+import { createPage } from '@/app/_helpers';
+import { useServerTranslation } from '@/shared/i18n';
+
+export async function _getPage(lng: string) {
+    const { t } = await useServerTranslation(lng, 'teachers');
+    return createPage({
+        buildPage: () => ({}),
+        buildSeo: () => ({
+            title: t('head-title'),
+            description: t('head-description'),
+            keywords: t('head-keywords'),
+        }),
+    });
+}

--- a/frontend-next-migration/src/app/[lng]/(helper)/teachers/results/page.ts
+++ b/frontend-next-migration/src/app/[lng]/(helper)/teachers/results/page.ts
@@ -1,0 +1,6 @@
+import { InstructionsPage } from '@/preparedPages/TeachersPage';
+import { withPageData, createMetadataGenerator } from '@/app/_helpers';
+import { _getPage } from './_getPage';
+
+export const generateMetadata = createMetadataGenerator(_getPage);
+export default withPageData(InstructionsPage, _getPage);

--- a/frontend-next-migration/src/features/NavigateTeachers/index.ts
+++ b/frontend-next-migration/src/features/NavigateTeachers/index.ts
@@ -1,0 +1,1 @@
+export { default as NavigateTeachers } from './ui/NavigateTeachers';

--- a/frontend-next-migration/src/features/NavigateTeachers/ui/NavigateTeachers.tsx
+++ b/frontend-next-migration/src/features/NavigateTeachers/ui/NavigateTeachers.tsx
@@ -1,0 +1,39 @@
+'use client';
+import { usePathname } from 'next/navigation';
+import { CustomSwitch, CustomSwitchItems } from '@/shared/ui/CustomSwitch';
+import { useMemo } from 'react';
+import { ProgressIndicator } from '@/shared/ui/CustomSwitch/model/types';
+import { useClientTranslation } from '@/shared/i18n';
+
+const NavigateTeachers = () => {
+    const { t } = useClientTranslation('teachers');
+    const path = usePathname().replace(/^\/[^/]+(?=\/teachers(?:\/|$))/, '');
+    const CustomSwitchElements: ProgressIndicator[] = useMemo(() => {
+        return [
+            {
+                children: <p>{t('instructions')}</p>,
+                isOpen: path === '/teachers/instructions',
+                type: CustomSwitchItems.ProgressIndicator,
+            },
+            {
+                children: <p>{t('preparation')}</p>,
+                isOpen: path === '/teachers/preparation',
+                type: CustomSwitchItems.ProgressIndicator,
+            },
+            {
+                children: <p>{t('gaming')}</p>,
+                isOpen: path === '/teachers/gaming',
+                type: CustomSwitchItems.ProgressIndicator,
+            },
+            {
+                children: <p>{t('results')}</p>,
+                isOpen: path === '/teachers/results',
+                type: CustomSwitchItems.ProgressIndicator,
+            },
+        ];
+    }, [path]);
+
+    return <CustomSwitch elements={CustomSwitchElements} />;
+};
+
+export default NavigateTeachers;

--- a/frontend-next-migration/src/preparedPages/TeachersPage/index.ts
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/index.ts
@@ -1,2 +1,3 @@
 export { default as TeachersPage } from './ui/TeachersPage';
+export { default as InstructionsPage } from './ui/InstructionsPage/InstructionsPage';
 export type { Props as TeachersPageProps } from './ui/TeachersPage';

--- a/frontend-next-migration/src/preparedPages/TeachersPage/index.ts
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/index.ts
@@ -1,3 +1,2 @@
 export { default as TeachersPage } from './ui/TeachersPage';
 export { default as InstructionsPage } from './ui/InstructionsPage/InstructionsPage';
-export type { Props as TeachersPageProps } from './ui/TeachersPage';

--- a/frontend-next-migration/src/preparedPages/TeachersPage/ui/InstructionsPage/InstructionPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/ui/InstructionsPage/InstructionPage.module.scss
@@ -1,0 +1,5 @@
+.Container {
+  width: 60%;
+  margin-left: auto;
+  margin-right: auto;
+}

--- a/frontend-next-migration/src/preparedPages/TeachersPage/ui/InstructionsPage/InstructionsPage.tsx
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/ui/InstructionsPage/InstructionsPage.tsx
@@ -1,0 +1,12 @@
+import { NavigateTeachers } from '@/features/NavigateTeachers';
+import cls from './InstructionPage.module.scss';
+
+const InstructionsPage = () => {
+    return (
+        <div className={cls.Container}>
+            <NavigateTeachers />
+        </div>
+    );
+};
+
+export default InstructionsPage;

--- a/frontend-next-migration/src/preparedPages/TeachersPage/ui/TeachersPage.async.tsx
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/ui/TeachersPage.async.tsx
@@ -1,6 +1,5 @@
 import dynamic from 'next/dynamic';
-import { Props } from './TeachersPage';
 
-const TeachersPageAsync = dynamic<Props>(() => import('./TeachersPage'));
+const TeachersPageAsync = dynamic(() => import('./TeachersPage'));
 
 export default TeachersPageAsync;

--- a/frontend-next-migration/src/preparedPages/TeachersPage/ui/TeachersPage.tsx
+++ b/frontend-next-migration/src/preparedPages/TeachersPage/ui/TeachersPage.tsx
@@ -1,13 +1,7 @@
 import cls from './TeachersPage.module.scss';
 import { ComingSoon } from '@/widgets/ComingSoon';
 
-export interface Props {
-    title: string;
-}
-
-const TeachersPage = (props: Props) => {
-    const { title } = props;
-
+const TeachersPage = () => {
     return (
         <div className={cls.Wrapper}>
             <ComingSoon />

--- a/frontend-next-migration/src/shared/i18n/locales/en/teachers.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/teachers.json
@@ -1,3 +1,6 @@
 {
-    
+  "instructions": "1. Instructions",
+  "preparation": "2. Preparation",
+  "gaming": "3. Gaming",
+  "results": "4. Results"
 }

--- a/frontend-next-migration/src/shared/i18n/locales/fi/teachers.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/teachers.json
@@ -1,0 +1,6 @@
+{
+  "instructions": "1. Ohjeet",
+  "preparation": "2. Valmistelu",
+  "gaming": "3. Pelaaminen",
+  "results": "4. Tulokset"
+}

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/index.ts
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/index.ts
@@ -1,3 +1,3 @@
 export { default as CustomSwitch } from './ui/CustomSwitch';
-export type { ToggleItem, ToggleLink } from './model/types';
+export type { ToggleItem, ToggleLink, ProgressIndicator } from './model/types';
 export { CustomSwitchItems } from './model/enum/CustomSwitch.enum';

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/model/enum/CustomSwitch.enum.ts
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/model/enum/CustomSwitch.enum.ts
@@ -1,4 +1,5 @@
 export enum CustomSwitchItems {
     ToggleItem = 'CustomSwitchToggleItem',
     ToggleLink = 'CustomSwitchToggleLink',
+    ProgressIndicator = 'CustomSwitchProgressIndicator',
 }

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/model/types/index.ts
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/model/types/index.ts
@@ -16,3 +16,9 @@ export type ToggleLink = {
     className?: string;
     children: ReactNode;
 };
+export type ProgressIndicator = {
+    type: CustomSwitchItems.ProgressIndicator;
+    isOpen: boolean;
+    className?: string;
+    children: ReactNode;
+};

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.module.scss
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.module.scss
@@ -35,3 +35,22 @@
         color: var(--black)
     }
 }
+.ProgressItem {
+    width:100%;
+    text-align: center;
+    color: var(--primary-color);
+    font-family: var(--body-font);
+    font-weight: bold;
+    font-size: var(--font-size-sm);
+    border: var(--border-mobile) solid var(--background);
+    border-radius: var(--border-radius-lg);
+    padding: .2em;
+}
+
+.ProgressItem.OpenToggleItem {
+    color: var(--black);
+}
+
+.BeforeOpen {
+    color: grey;
+}

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.tsx
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { classNames } from '@/shared/lib/classNames/classNames';
 import { AppLink } from '@/shared/ui/AppLink/AppLink';
-import { CustomSwitchItems } from '@/shared/ui/CustomSwitch';
-import { ToggleItem, ToggleLink, ProgressIndicator } from '../model/types/';
 import cls from './CustomSwitch.module.scss';
+import { CustomSwitchItems } from '@/shared/ui/CustomSwitch';
+import type { ToggleItem, ToggleLink, ProgressIndicator } from '../model/types';
 
 export interface CustomSwitchProps {
     elements: ToggleItem[] | ToggleLink[] | ProgressIndicator[];

--- a/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.tsx
+++ b/frontend-next-migration/src/shared/ui/CustomSwitch/ui/CustomSwitch.tsx
@@ -1,12 +1,12 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { classNames } from '@/shared/lib/classNames/classNames';
 import { AppLink } from '@/shared/ui/AppLink/AppLink';
-import { CustomSwitchItems } from '../model/enum/CustomSwitch.enum';
-import { ToggleItem, ToggleLink } from '../model/types/';
+import { CustomSwitchItems } from '@/shared/ui/CustomSwitch';
+import { ToggleItem, ToggleLink, ProgressIndicator } from '../model/types/';
 import cls from './CustomSwitch.module.scss';
 
 export interface CustomSwitchProps {
-    elements: ToggleItem[] | ToggleLink[];
+    elements: ToggleItem[] | ToggleLink[] | ProgressIndicator[];
     className?: string;
 }
 
@@ -49,6 +49,9 @@ const CustomSwitch = ({ elements, className }: CustomSwitchProps) => {
         {},
         [className].filter((i) => i !== undefined),
     );
+
+    const openIndex = elements.findIndex((elem) => elem.isOpen);
+
     return (
         <div className={customSwitchClassName}>
             {elements.map((element, index) => (
@@ -69,6 +72,16 @@ const CustomSwitch = ({ elements, className }: CustomSwitchProps) => {
                                 [cls.OpenToggleItem]: element.isOpen,
                             })}
                             onClick={element.onOpen}
+                        >
+                            {element.children}
+                        </div>
+                    )}
+                    {element.type === CustomSwitchItems.ProgressIndicator && (
+                        <div
+                            className={classNames(cls.ProgressItem, {
+                                [cls.OpenToggleItem]: element.isOpen,
+                                [cls.BeforeOpen]: openIndex !== -1 && index < openIndex,
+                            })}
                         >
                             {element.children}
                         </div>


### PR DESCRIPTION
## 📄 **Pull Request Overview**
Extended the CustomSwitch component to display as a progress indicator, with the previous steps of the active route shown in gray. In this mode, the CustomSwitch component does not itself act as a navigation element but instead shows the stage of the teachers page based on the current route. For testing purposes, the routes `/teachers/instructions`, `/teachers/preparation`, `/teachers/gaming`, and `/teachers/results were created.`
Closes [#519]

## 🔧 **Changes Made**

1. [Briefly describe changes you made]
Added the NavigateTeachers component, which uses the CustomSwitch component.    
Added element.type === CustomSwitchItems.ProgressIndicator handling to the CustomSwitch component, to the types, and the required CSS.


## 📝 **Additional Information**
<img width="823" height="122" alt="Screenshot 2025-08-22 085223" src="https://github.com/user-attachments/assets/2749dadf-ec76-4402-8600-0f14a3d93683" />


<img width="813" height="125" alt="Screenshot 2025-08-22 085146" src="https://github.com/user-attachments/assets/38e3767d-3d9d-41ce-8e7e-1cc7aadffb75" />
