### PR TITLE
Liemng/feature/520 implement a redirect for all undefined routes to lngcoming page

### DIFF
--- a/frontend-next-migration/src/app/[lng]/[...notFound]/page.tsx
+++ b/frontend-next-migration/src/app/[lng]/[...notFound]/page.tsx
@@ -1,5 +1,4 @@
 'use client';
-// import { useEffect } from 'react';
 import { useParams, redirect } from 'next/navigation';
 
 export default function NotFoundCatchAll() {

--- a/frontend-next-migration/src/app/[lng]/[...notFound]/page.tsx
+++ b/frontend-next-migration/src/app/[lng]/[...notFound]/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+// import { useEffect } from 'react';
+import { useParams, redirect } from 'next/navigation';
+
+export default function NotFoundCatchAll() {
+    const params = useParams();
+
+    if (params?.lng) {
+        redirect(`/${params.lng}/coming`);
+    }
+
+    return null;
+}


### PR DESCRIPTION
## 📄 **Pull Request Overview**

Closes [#520 ]

## 🔧 **Changes Made**

Created a dynamic catch-all not found page for [lng] routes. Users are redirected to corresponding /coming page of the current language parameter.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.✅
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.✅
- **Clean Code**: Removed commented-out or unnecessary code.✅
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: 

https://github.com/user-attachments/assets/64fe41dd-53e1-43bd-ba87-7f86db4923de

- **Dependencies**: no new dependencies added.

