### PR TITLE
580-bug-team-and-about-page-error

### DIFF
--- a/frontend-next-migration/src/entities/About/api/aboutApi.ts
+++ b/frontend-next-migration/src/entities/About/api/aboutApi.ts
@@ -22,7 +22,7 @@ const client = createDirectus(directusBaseUrl).with(rest());
 
 export const aboutApi = directusApi.injectEndpoints({
     endpoints: (builder) => ({
-        getMembers: builder.query<number, void>({
+        getMembersCount: builder.query<number, void>({
             queryFn: async () => {
                 try {
                     const members = await client.request<Member[]>(
@@ -96,4 +96,4 @@ export const aboutApi = directusApi.injectEndpoints({
     overrideExisting: false,
 });
 
-export const { useGetMembersQuery, useGetDemographicsQuery } = aboutApi;
+export const { useGetMembersCountQuery, useGetDemographicsQuery } = aboutApi;

--- a/frontend-next-migration/src/entities/About/api/index.ts
+++ b/frontend-next-migration/src/entities/About/api/index.ts
@@ -1,1 +1,1 @@
-export { useGetMembersQuery, useGetDemographicsQuery } from './aboutApi';
+export { useGetMembersCountQuery, useGetDemographicsQuery } from './aboutApi';

--- a/frontend-next-migration/src/entities/About/index.ts
+++ b/frontend-next-migration/src/entities/About/index.ts
@@ -1,2 +1,2 @@
-export { useGetMembersQuery, useGetDemographicsQuery } from './api';
+export { useGetMembersCountQuery, useGetDemographicsQuery } from './api';
 export { getBehindYears } from './lib';

--- a/frontend-next-migration/src/entities/Member/api/mappers.ts
+++ b/frontend-next-migration/src/entities/Member/api/mappers.ts
@@ -97,12 +97,6 @@ export const organizeMembers = (members: Member[], lng: string) => {
     const order = lng === 'fi' ? fiOrder : enOrder;
     const departmentOrder = lng === 'fi' ? fiDepartmentOrder : enDepartmentOrder;
 
-    // crutch fix for directus returning invalid data
-    if (!Array.isArray(members)) {
-        console.warn('Invalid members passed to organizeMembers', members);
-        return { teamsMap: new Map<number, Team>() };
-    }
-
     members.forEach((member: Member) => {
         const memberTeam = member.team;
         const memberDepartment = member.department;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -9,7 +9,7 @@ import img2021 from '@/shared/assets/images/aboutPage/about2021.png';
 import img2022 from '@/shared/assets/images/aboutPage/about2022.png';
 import img2023 from '@/shared/assets/images/aboutPage/about2023.png';
 import img2024 from '@/shared/assets/images/aboutPage/about2024.png';
-import { useGetMembersQuery, useGetDemographicsQuery, getBehindYears } from '@/entities/About';
+import { useGetMembersCountQuery, useGetDemographicsQuery, getBehindYears } from '@/entities/About';
 
 export interface Props {
     title: string;
@@ -46,7 +46,7 @@ const About = (props: Props) => {
         V2024,
     } = props;
 
-    const { data: projectCount = 0, isLoading: membersLoading } = useGetMembersQuery();
+    const { data: projectCount = 0, isLoading: membersLoading } = useGetMembersCountQuery();
     const {
         data: demographics = { localities: 0, nationalities: 0 },
         isLoading: demographicsLoading,
@@ -76,14 +76,7 @@ const About = (props: Props) => {
                 <p className={`${cls.h1}`}>{keywords}</p>
                 <div className={cls.headergrid}>
                     <div>
-                        {/* Fix bug with directus returning invalid type */}
-                        <p className={cls.sValues}>
-                            {isLoading
-                                ? '...'
-                                : typeof projectCount === 'number'
-                                  ? projectCount
-                                  : 'NaN'}
-                        </p>
+                        <p className={cls.sValues}>{isLoading ? '...' : projectCount}</p>
                         <p className={cls.gridp}>{project}</p>
                     </div>
                     <div>

--- a/frontend-next-migration/src/widgets/SectionMembers/ui/SectionMembers.tsx
+++ b/frontend-next-migration/src/widgets/SectionMembers/ui/SectionMembers.tsx
@@ -28,12 +28,6 @@ export const SectionMembers: FC<WorkersSectionProps> = ({ className = '' }) => {
 
     const { teamsMap } = organizeMembers(members, lng);
 
-    // If no members found, reload the page (to fix potential Directus caching issues)
-    if (teamsMap.size === 0 && !isLoading && !isError) {
-        location.reload();
-        return <p>{_t('no-members')}</p>;
-    }
-
     return (
         <div className={classNames(cls.MembersSection, {}, [className])}>
             {/*<ScrollBottomButton


### PR DESCRIPTION
## 📄 **Pull Request Overview**
The issue between the team and about pages was that their different injections had the same name, meaning they used the same cache key. The problem was fixed by renaming About API's getMembers -> getMembersCount
Closes #580

