### PR TITLE
adjusted the newsApi to use the new formatDateDMY function and added …

### DIFF
--- a/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsElementPage/ui/NewsElementPage.module.scss
+++ b/frontend-next-migration/src/preparedPages/NewsPages/ui/NewsElementPage/ui/NewsElementPage.module.scss
@@ -75,7 +75,7 @@
     width: 100%;
     margin: 0 auto;
     @media (max-width: breakpoint(md)) {
-        font:var(--font-sw-l)
+        font: var(--font-sw-l);
     }
 }
 
@@ -111,6 +111,7 @@
     gap: 20px;
     grid-template-columns: repeat(auto-fill, minmax(450px, 1fr));
     justify-content: center;
+    margin-bottom: 1.5em;
 }
 
 .readmoreText {

--- a/frontend-next-migration/src/shared/lib/formatDate/formatDateDMY.ts
+++ b/frontend-next-migration/src/shared/lib/formatDate/formatDateDMY.ts
@@ -1,0 +1,9 @@
+export function formatDateToDMY(date?: string | Date | null): string {
+    if (!date) return '';
+    const parsedDate = typeof date === 'string' ? new Date(date) : date;
+    if (Number.isNaN(parsedDate.getTime())) return '';
+    const day = parsedDate.getDate();
+    const month = parsedDate.getMonth() + 1;
+    const year = parsedDate.getFullYear();
+    return `${day}.${month}.${year}`;
+}

--- a/frontend-next-migration/src/shared/lib/formatDate/index.ts
+++ b/frontend-next-migration/src/shared/lib/formatDate/index.ts
@@ -1,0 +1,1 @@
+export * from './formatDateDMY';


### PR DESCRIPTION


## 📄 **Pull Request Overview**

Closes #573 

## 🔧 **Changes Made**
### Utilities
- Added `formatDateToDMY` utility (formats dates as D.M.YYYY).
  - Location: src/shared/lib/formatDate/formatDateDMY.ts
  - Signature: `formatDateToDMY(date?: string | Date | null): string`
  - Behavior: accepts `string | Date | null`, returns `''` for falsy or invalid dates, otherwise returns `day.month.year` (no leading zeros).

### Backend / API
- Formatted date fields to D.M.YYYY in API responses:
  - Applied in `getNews` and `getNewsById` (newsApi).
  - Preserves original date value when querying next/previous items; only the returned object is formatted.

### UI / Styles
- Added small margin-bottom to newElementPage.scss.module -> .newsGrid
---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected.
- **JSDoc**: I have added or updated JSDoc comments for all relevant code.
- **Debugging**: No `console.log()` or other debugging statements are left.
- **Clean Code**: Removed commented-out or unnecessary code.
- **Tests**: Added new tests or updated existing ones for the changes made.
- **Documentation**: Documentation has been updated (if applicable).

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: [Include any screenshots or videos if the changes affect the UI]
- **Dependencies**: [Mention any new dependencies or breaking changes]
- **Known Issues**: [List any known issues or limitations]
