### PR TITLE
Eemeli/enhancement/659/about page update

### DIFF
--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -377,38 +377,66 @@
 
 .timelineSortDropdown {
     position: relative;
-    width: 180px;
-    z-index: 20;
-}
+    width: 220px;
+    max-height: 40px;
 
-.timelineSortHeader {
-    position: relative;
+    overflow: hidden;
     box-sizing: border-box;
-
-    width: 180px;
-    min-height: 40px;
-    padding: 8px 14px;
 
     background: #1E3544;
 
     border-radius: var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 6px 6px #121212;
+
+    z-index: 20;
+
+    transition: max-height 0.3s ease;
+}
+
+.timelineSortDropdown[data-dropdown-state='opening'],
+.timelineSortDropdown[data-dropdown-state='open'] {
+    max-height: 140px;
+}
+
+.timelineSortDropdown[data-dropdown-state='closing'] {
+    max-height: 40px;
+}
+
+.timelineSortHeader {
+    position: relative;
+    box-sizing: border-box;
+
+    width: 100%;
+    min-height: 40px;
+    padding: 8px 14px;
+
+    background: transparent;
+
+    border-radius: 0;
+
+    outline: none;
+    box-shadow: none;
+}
+
+.timelineSortChevron {
+    width: 16px;
+    height: 16px;
 }
 
 .timelineSortContent {
     position: relative;
 
     box-sizing: border-box;
-    width: 180px;
+    width: 100%;
 
     padding: 8px 10px 10px;
 
-    background: #1E3544;
+    background: transparent;
 
-    border-radius: 0 0 var(--corner-radius-web) var(--corner-radius-web);
-    outline: var(--thickness-web) solid var(--black);
-    box-shadow: 6px 6px #121212;
+    border: none;
+    outline: none;
+    box-shadow: none;
 
     z-index: 21;
 }
@@ -423,6 +451,11 @@
     padding-left: 34px;
 
     box-sizing: border-box;
+
+    font: var(--font-dm-bold-m);
+    font-size: 16px;
+    line-height: 1.2 !important;
+    white-space: nowrap;
 
     color: var(--white) !important;
     cursor: pointer;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -239,6 +239,12 @@
     z-index: 2;
 }
 
+@media (max-width: breakpoint(sm)) {
+    .timelineChevron {
+        left: -14.5px;
+    }
+}
+
 #line::before {
     content: '';
     position: absolute;
@@ -249,6 +255,22 @@
     bottom: 40px;
     z-index: 1;
     border-radius: 999px;
+}
+
+@media (max-width: breakpoint(sm)) {
+    .timelineCard::before {
+        width: 24px;
+        height: 24px;
+        left: -33px;
+    }
+
+    #line::before {
+        left: 1px;
+    }
+
+    .timelineChevron {
+        left: -8.5px;
+    }
 }
 
 #line.timelineNewest::before {
@@ -505,16 +527,29 @@
 }
 
 .timelineHeader {
+    position: relative;
+
     display: flex;
     justify-content: space-between;
     align-items: center;
+
+    width: 100%;
+    box-sizing: border-box;
 
     cursor: pointer;
     user-select: none;
 
     min-height: 64px;
-    padding: 0 16px;
+    padding: 0;
     margin-bottom: 0;
+}
+
+@media (max-width: breakpoint(md)) {
+    .timelineHeader .yearh1 {
+        margin: 0;
+        padding: 0;
+        line-height: 1;
+    }
 }
 
 .timelineHeader .yearh1::before {
@@ -628,6 +663,14 @@
     z-index: 2;
 }
 
+@media (max-width: breakpoint(sm)) {
+    .timelineCard::before {
+        width: 24px;
+        height: 24px;
+        left: -33px;
+    }
+}
+
 .timelineNewest .timelineStart::before {
     display: none;
 }
@@ -636,26 +679,35 @@
     display: none;
 }
 
-.chevron {
+.timelineChevronWrapper {
     display: flex;
     align-items: center;
     justify-content: center;
+
     flex-shrink: 0;
-    margin-left: 1rem;
+
     width: 24px;
     height: 24px;
 
     transform: rotate(0deg);
+    transform-origin: center;
     transition: transform 0.3s ease;
+}
+
+.timelineChevronWrapperOpen {
+    transform: rotate(180deg);
+}
+
+.chevron {
+    width: 24px;
+    height: 24px;
+
+    flex-shrink: 0;
 
     img {
         width: 100%;
         height: 100%;
     }
-}
-
-.chevronOpen {
-    transform: rotate(180deg);
 }
 
 .aboutContent {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -36,6 +36,8 @@
 }
 
 .containerBottom {
+    position: relative;
+
     background: var(--background);
     text-align: center;
     border-radius: var(--corner-radius-web);
@@ -158,6 +160,7 @@
         font: var(--font-sw-l);
     }
 }
+
 .p {
     font: var(--font-dm-s);
     text-align: left;
@@ -184,6 +187,7 @@
     padding: 0;
     margin: 0 0 2px;
 }
+
 .yearh1 {
     font: var(--font-sw-xl);
     color: var(--primary-color);
@@ -214,11 +218,9 @@
 
 #line {
     position: relative;
-
     width: 95%;
     margin-left: 5%;
     margin-bottom: var(--spacing-600);
-
     box-sizing: border-box;
     border-left: none;
 }
@@ -226,35 +228,48 @@
 #line::before {
     content: '';
     position: absolute;
-
     width: 5px;
-
     background: #FFA100;
-
     left: -9px;
     top: 38px;
     bottom: 40px;
-
     z-index: 1;
 }
 
 #line::after {
     content: '';
     position: absolute;
-
     width: 16px;
     height: 16px;
-
     border-left: 4px solid #FFA100;
     border-top: 4px solid #FFA100;
-
     left: -14.5px;
     top: 28px;
-
     transform: rotate(45deg);
-
     box-sizing: border-box;
     z-index: 2;
+}
+
+#line.timelineNewest::before {
+    top: 4px;
+    bottom: 40px;
+}
+
+#line.timelineOldest::before {
+    top: 40px;
+    bottom: 4px;
+}
+
+#line.timelineNewest::after {
+    top: 2px;
+    bottom: auto;
+    transform: rotate(45deg);
+}
+
+#line.timelineOldest::after {
+    top: auto;
+    bottom: -2px;
+    transform: rotate(225deg);
 }
 
 #History {
@@ -330,21 +345,106 @@
     }
 }
 
+/*
+ * Timeline sort dropdown
+ */
 .sortContainer {
-    display: flex;
-    justify-content: flex-end;
-    align-items: center;
-    gap: var(--spacing-sm);
-    margin-bottom: var(--spacing-400);
-    padding-right: var(--spacing-400);
+    position: absolute;
+    top: 0;
+    right: 0;
+    z-index: 20;
 }
 
-.sortContainer select {
-    padding: 0.4rem 0.8rem;
+.timelineSortDropdown {
+    position: relative;
+    width: 180px;
+    z-index: 20;
+}
+
+.timelineSortHeader {
+    position: relative;
+    box-sizing: border-box;
+    width: 180px;
+    min-height: 40px;
+    padding: 8px 14px;
+
+    background: #1E3544;
     border-radius: var(--corner-radius-web);
-    border: 2px solid var(--black);
-    background: var(--background);
+    outline: var(--thickness-web) solid var(--black);
+    box-shadow: 6px 6px #121212;
+}
+
+.timelineSortContent {
+    position: absolute;
+    top: 100%;
+    right: 0;
+
+    box-sizing: border-box;
+    width: 180px;
+    padding: 8px 10px 10px;
+
+    background: #1E3544;
+    border-radius: 0 0 var(--corner-radius-web) var(--corner-radius-web);
+    outline: var(--thickness-web) solid var(--black);
+    box-shadow: 6px 6px #121212;
+
+    z-index: 21;
+}
+
+.timelineSortItem {
+    position: relative;
+    display: flex;
+    align-items: center;
+
+    min-height: 40px;
+    padding-left: 34px;
+
+    box-sizing: border-box;
+
+    color: var(--white);
     cursor: pointer;
+    text-decoration: none;
+}
+
+.timelineSortItem::before {
+    content: '';
+
+    position: absolute;
+    left: 0;
+
+    width: 20px;
+    height: 20px;
+
+    box-sizing: border-box;
+
+    background: #d9d9d9;
+    border: 1px solid #121212;
+    border-radius: 2px;
+}
+
+.timelineSortItem.active {
+    color: var(--white) !important;
+    text-decoration: none !important;
+}
+
+.timelineSortItem.active::before {
+    background: #FFA100;
+}
+
+.timelineSortItem.active::after {
+    content: '';
+
+    position: absolute;
+    left: 5px;
+    top: 12px;
+
+    width: 8px;
+    height: 4px;
+
+    border-left: 3px solid #121212;
+    border-bottom: 3px solid #121212;
+
+    transform: rotate(-45deg);
 }
 
 .timelineHeader {
@@ -366,11 +466,6 @@
 
 .timelineBody {
     width: 100%;
-}
-
-.chevron {
-    font-size: 1.5rem;
-    color: var(--primary-color);
 }
 
 .timelineCard {
@@ -414,7 +509,11 @@
     z-index: 2;
 }
 
-.timelineCard:first-child::before {
+.timelineNewest .timelineStart::before {
+    display: none;
+}
+
+.timelineOldest .timelineEnd::before {
     display: none;
 }
 

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -3,19 +3,6 @@
     justify-items: center;
 }
 
-.hero {
-    position: relative;
-    width: 100%;
-    max-width: 1400px;
-    aspect-ratio: 16 / 9;
-    margin-bottom: var(--spacing-600);
-}
-
-.heroImg {
-    object-fit: cover;
-    max-width: 1400px;
-}
-
 .containerTop {
     background: var(--background);
     text-align: center;
@@ -25,6 +12,7 @@
     margin-bottom: 5%;
     padding: 1.2rem;
     width: 30%;
+    box-sizing: border-box;
 
     @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
         width: 40%;
@@ -79,19 +67,48 @@
 
 .headergrid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(4, 130px);
     gap: 32px;
-    padding: 0 64px;
+    padding: 8px 0 0;
+    width: 100%;
+    box-sizing: border-box;
+    justify-content: center;
     grid-template-rows: 1;
 
+    @media (max-width: breakpoint(xxl)) {
+        grid-template-columns: repeat(2, 130px);
+        gap: 20px 28px;
+        justify-content: center;
+    }
+
+    @media (max-width: breakpoint(xl)) {
+        grid-template-columns: repeat(2, 130px);
+        gap: 16px 24px;
+        justify-content: center;
+    }
+
+    @media (max-width: breakpoint(lg)) {
+        grid-template-columns: repeat(2, 130px);
+        gap: 16px;
+        justify-content: center;
+    }
+
     @media (max-width: breakpoint(md)) {
-        grid-template-columns: 50% 50%;
-        padding: 0 24px;
+        grid-template-columns: repeat(2, 130px);
+        gap: 12px;
+        justify-content: center;
     }
 
     @media (max-width: breakpoint(sm)) {
-        grid-template-columns: 50% 50%;
-        padding: 0 16px;
+        grid-template-columns: repeat(2, 130px);
+        gap: 12px;
+        justify-content: center;
+    }
+
+    @media (max-width: 1600px) {
+        grid-template-columns: repeat(2, 130px);
+        gap: 16px 24px;
+        justify-content: center;
     }
 }
 
@@ -364,13 +381,20 @@
     border: 2px solid var(--black);
     border-radius: var(--corner-radius-web);
     padding: 6px 8px;
-    min-height: 68px;
+    width: 130px;
+    height: 84px;
     box-sizing: border-box;
 
     display: flex;
     flex-direction: column;
     align-items: center;
     justify-content: center;
+}
+
+.statItemNarrow .gridp {
+    max-width: 90px;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 .statItem .gridp {
@@ -380,11 +404,34 @@
     text-align: center;
     padding: 0;
     margin: 0;
+    white-space: normal;
 }
 
 .statsTitle {
     font: var(--font-sw-l);
+    font-size: 22px;
     color: var(--primary-color);
     text-align: center;
-    margin: 0;
+    margin: 0 auto;
+    letter-spacing: -0.03em;
+    width: 100%;
+    max-width: 100%;
+    box-sizing: border-box;
+    white-space: normal;
+    overflow-wrap: break-word;
+
+    @media (max-width: breakpoint(xl)) {
+        font-size: 20px;
+        line-height: 1.2;
+    }
+
+    @media (max-width: breakpoint(md)) {
+        font-size: 18px;
+        line-height: 1.2;
+    }
+
+    @media (max-width: breakpoint(sm)) {
+        font-size: 16px;
+        line-height: 1.2;
+    }
 }

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -43,7 +43,7 @@
     border-radius: var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 10px 10px #121212;
-    margin-bottom: 5%;
+    margin-bottom: 30px;
     width: 40%;
 
     transition: margin-top 0.3s ease;
@@ -66,6 +66,60 @@
 
     @media (max-width: breakpoint(sm)) {
         width: 90%;
+    }
+}
+
+.designerContainer {
+    width: 40%;
+    box-sizing: border-box;
+
+    background: var(--background);
+    border-radius: var(--corner-radius-web);
+    outline: var(--thickness-web) solid var(--black);
+    box-shadow: 10px 10px #121212;
+
+    padding: 16px 16px;
+
+    position: relative;
+    top: -22px;
+
+    display: flex;
+    justify-content: center;
+    align-items: center;
+
+    @media (max-width: breakpoint(xxl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(xl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(md)) {
+        width: 70%;
+    }
+
+    @media (max-width: breakpoint(sm)) {
+        width: 90%;
+    }
+}
+
+.designerText {
+    font: var(--font-dm-m);
+    font-size: 16px;
+    line-height: 1.2;
+    color: var(--white);
+    text-align: center;
+    margin: 0;
+
+    span {
+        color: var(--primary-color);
+    }
+
+    @media (max-width: breakpoint(sm)) {
+        span {
+            display: block;
+        }
     }
 }
 
@@ -598,6 +652,7 @@
     height: 4px;
     background: #FFA100;
     margin-bottom: var(--spacing-400);
+    border-radius: 999px;
 }
 
 .timelineCloseButton {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -46,6 +46,8 @@
     margin-bottom: 5%;
     width: 30%;
 
+    transition: margin-top 0.3s ease;
+
     @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
         width: 40%;
     }
@@ -348,11 +350,37 @@
 /*
  * Timeline sort dropdown
  */
+/*
+ * Timeline sort dropdown
+ */
 .sortContainer {
-    position: absolute;
-    top: 0;
-    right: 0;
+    width: 30%;
+    display: flex;
+    justify-content: flex-end;
+
+    margin-bottom: 12px;
+
     z-index: 20;
+
+    @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
+        width: 40%;
+    }
+
+    @media (max-width: breakpoint(xxl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(xl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(md)) {
+        width: 70%;
+    }
+
+    @media (max-width: breakpoint(sm)) {
+        width: 90%;
+    }
 }
 
 .timelineSortDropdown {
@@ -364,26 +392,28 @@
 .timelineSortHeader {
     position: relative;
     box-sizing: border-box;
+
     width: 180px;
     min-height: 40px;
     padding: 8px 14px;
 
     background: #1E3544;
+
     border-radius: var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 6px 6px #121212;
 }
 
 .timelineSortContent {
-    position: absolute;
-    top: 100%;
-    right: 0;
+    position: relative;
 
     box-sizing: border-box;
     width: 180px;
+
     padding: 8px 10px 10px;
 
     background: #1E3544;
+
     border-radius: 0 0 var(--corner-radius-web) var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 6px 6px #121212;
@@ -393,6 +423,7 @@
 
 .timelineSortItem {
     position: relative;
+
     display: flex;
     align-items: center;
 
@@ -401,9 +432,9 @@
 
     box-sizing: border-box;
 
-    color: var(--white);
+    color: var(--white) !important;
     cursor: pointer;
-    text-decoration: none;
+    text-decoration: none !important;
 }
 
 .timelineSortItem::before {
@@ -411,6 +442,7 @@
 
     position: absolute;
     left: 0;
+    top: 50%;
 
     width: 20px;
     height: 20px;
@@ -420,31 +452,33 @@
     background: #d9d9d9;
     border: 1px solid #121212;
     border-radius: 2px;
+
+    transform: translateY(-50%);
 }
 
-.timelineSortItem.active {
+.timelineSortItemActive {
     color: var(--white) !important;
     text-decoration: none !important;
 }
 
-.timelineSortItem.active::before {
+.timelineSortItemActive::before {
     background: #FFA100;
 }
 
-.timelineSortItem.active::after {
+.timelineSortItemActive::after {
     content: '';
 
     position: absolute;
-    left: 5px;
-    top: 12px;
+    left: 6px;
+    top: 50%;
 
-    width: 8px;
-    height: 4px;
+    width: 6px;
+    height: 11px;
 
-    border-left: 3px solid #121212;
+    border-right: 3px solid #121212;
     border-bottom: 3px solid #121212;
 
-    transform: rotate(-45deg);
+    transform: translateY(-65%) rotate(45deg);
 }
 
 .timelineHeader {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -96,6 +96,7 @@
     flex-direction: column;
     gap: var(--spacing-400);
     white-space: pre-line;
+    width: 100%;
 }
 
 .yearImgWrap {
@@ -186,13 +187,38 @@
 }
 
 #line {
+    width: 95%;
     border-left: 10px solid orange;
     margin-left: 5%;
     margin-bottom: var(--spacing-600);
+    box-sizing: border-box;
 }
 
 #History {
+    width: 30%;
     padding-bottom: var(--spacing-600);
+    text-align: left;
+    margin-bottom: var(--spacing-400);
+
+    @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
+        width: 40%;
+    }
+
+    @media (max-width: breakpoint(xxl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(xl)) {
+        width: 50%;
+    }
+
+    @media (max-width: breakpoint(md)) {
+        width: 70%;
+    }
+
+    @media (max-width: breakpoint(sm)) {
+        width: 90%;
+    }
 }
 
 .chevronImage {
@@ -267,7 +293,7 @@
 
     min-height: 48px;
     padding: 0 var(--spacing-300);
-    margin-bottom: var(--spacing-300);
+    margin-bottom: 0;
 }
 
 .timelineBody {
@@ -279,8 +305,12 @@
     color: var(--primary-color);
 }
 .timelineCard {
-    width: 100%;
+    width: calc(100% - var(--spacing-400));
+    box-sizing: border-box;
+
+    margin-left: var(--spacing-400);
     margin-bottom: var(--spacing-400);
+
     padding: var(--spacing-400);
 
     background: var(--background);
@@ -311,4 +341,10 @@
 
 .chevronOpen {
     transform: rotate(180deg);
+}
+
+.aboutContent {
+    width: 100%;
+    display: grid;
+    justify-items: center;
 }

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -196,6 +196,7 @@
 
 #History {
     width: 30%;
+    font: var(--font-sw-4xl);
     padding-bottom: var(--spacing-600);
     text-align: left;
     margin-bottom: var(--spacing-400);
@@ -347,4 +348,10 @@
     width: 100%;
     display: grid;
     justify-items: center;
+}
+
+.statItem {
+    background: var(--background);
+    border: 2px solid var(--black);
+    border-radius: var(--corner-radius-web);
 }

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -119,9 +119,13 @@
 .storygrid {
     display: flex;
     flex-direction: column;
-    gap: var(--spacing-400);
+    gap: 36px;
     white-space: pre-line;
     width: 100%;
+    box-sizing: border-box;
+
+    margin-top: 28px;
+    margin-bottom: 28px;
 }
 
 .yearImgWrap {
@@ -194,7 +198,7 @@
     font: var(--font-sw-xl);
     color: var(--primary-color);
     text-align: left;
-    margin-top: -16px;
+    margin-top: 0;
 
     @media (max-width: breakpoint(sm)) {
         text-align: left;
@@ -210,7 +214,7 @@
 
     @media (max-width: breakpoint(lg)) {
         font: var(--font-sw-l);
-        margin-top: -12px;
+        margin-top: 0;
     }
 }
 
@@ -222,9 +226,19 @@
     position: relative;
     width: 95%;
     margin-left: 5%;
-    margin-bottom: var(--spacing-600);
     box-sizing: border-box;
     border-left: none;
+}
+
+.timelineChevron {
+    position: absolute;
+
+    width: 24px;
+    height: 24px;
+
+    left: -18.5px;
+
+    z-index: 2;
 }
 
 #line::before {
@@ -236,42 +250,26 @@
     top: 38px;
     bottom: 40px;
     z-index: 1;
-}
-
-#line::after {
-    content: '';
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    border-left: 4px solid #FFA100;
-    border-top: 4px solid #FFA100;
-    left: -14.5px;
-    top: 28px;
-    transform: rotate(45deg);
-    box-sizing: border-box;
-    z-index: 2;
+    border-radius: 999px;
 }
 
 #line.timelineNewest::before {
-    top: 4px;
+    top: 40px;
     bottom: 40px;
 }
 
 #line.timelineOldest::before {
     top: 40px;
-    bottom: 4px;
+    bottom: 40px;
 }
 
-#line.timelineNewest::after {
-    top: 2px;
-    bottom: auto;
-    transform: rotate(45deg);
+.timelineNewest .timelineChevron {
+    top: 22px;
+    transform: rotate(180deg);
 }
 
-#line.timelineOldest::after {
-    top: auto;
-    bottom: -2px;
-    transform: rotate(225deg);
+.timelineOldest .timelineChevron {
+    bottom: 22px;
 }
 
 #History {
@@ -347,12 +345,6 @@
     }
 }
 
-/*
- * Timeline sort dropdown
- */
-/*
- * Timeline sort dropdown
- */
 .sortContainer {
     width: 30%;
     display: flex;
@@ -509,7 +501,6 @@
     box-sizing: border-box;
 
     margin-left: var(--spacing-400);
-    margin-bottom: 20px;
 
     padding: 0 24px;
 
@@ -521,6 +512,10 @@
     outline: var(--thickness-web) solid var(--black);
 
     box-shadow: 6px 6px #121212;
+}
+
+.timelineCard:last-child {
+    margin-bottom: 0;
 }
 
 .timelineCard::before {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -9,9 +9,9 @@
     border-radius: var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 10px 10px #121212;
-    margin-bottom: 5%;
+    margin-bottom: 2%;
     padding: 1.2rem;
-    width: 30%;
+    width: 40%;
     box-sizing: border-box;
 
     @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
@@ -44,7 +44,7 @@
     outline: var(--thickness-web) solid var(--black);
     box-shadow: 10px 10px #121212;
     margin-bottom: 5%;
-    width: 30%;
+    width: 40%;
 
     transition: margin-top 0.3s ease;
 
@@ -72,7 +72,8 @@
 .headergrid {
     display: grid;
     grid-template-columns: repeat(4, 130px);
-    gap: 32px;
+    column-gap: 44px;
+    row-gap: 32px;
     padding: 8px 0 0;
     width: 100%;
     box-sizing: border-box;
@@ -182,7 +183,7 @@
 }
 
 .sValues {
-    font: var(--font-sw-xxl);
+    font: var(--font-sw-l);
     color: #FFA100;
     font-weight: 400;
     line-height: 100%;
@@ -293,7 +294,7 @@
 }
 
 #History {
-    width: 30%;
+    width: 40%;
     font: var(--font-sw-4xl);
     padding-bottom: var(--spacing-600);
     text-align: left;
@@ -366,7 +367,7 @@
 }
 
 .sortContainer {
-    width: 30%;
+    width: 40%;
     display: flex;
     justify-content: flex-end;
 
@@ -439,9 +440,13 @@
     box-shadow: none;
 }
 
-.timelineSortChevron {
-    width: 16px;
-    height: 16px;
+.timelineSortChevronWrapper {
+    margin-right: 12px;
+}
+
+.timelineSortHeader :global(img) {
+    width: 14px !important;
+    height: 14px !important;
 }
 
 .timelineSortContent {
@@ -472,8 +477,8 @@
 
     box-sizing: border-box;
 
-    font: var(--font-dm-bold-m);
-    font-size: 16px;
+    font: var(--font-dm-m);
+    font-size: 14px;
     line-height: 1.2 !important;
     white-space: nowrap;
 
@@ -609,7 +614,7 @@
 
     box-shadow: 4px 4px #121212;
 
-    font: var(--font-dm-bold-s);
+    font: var(--font-dm-s);
     cursor: pointer;
 
     display: flex;
@@ -722,7 +727,7 @@
     border-radius: var(--corner-radius-web);
     padding: 6px 8px;
     width: 130px;
-    height: 84px;
+    height: 92px;
     box-sizing: border-box;
 
     display: flex;
@@ -739,7 +744,7 @@
 
 .statItem .gridp {
     font: var(--font-dm-bold-s);
-    font-size: 12px;
+    font-size: 13px;
     line-height: 1.2;
     text-align: center;
     padding: 0;
@@ -749,7 +754,7 @@
 
 .statsTitle {
     font: var(--font-sw-l);
-    font-size: 22px;
+    font-size: 26px;
     color: var(--primary-color);
     text-align: center;
     margin: 0 auto;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -264,7 +264,10 @@
 
     cursor: pointer;
     user-select: none;
-    padding: var(--spacing-300) 0;
+
+    min-height: 48px;
+    padding: 0 var(--spacing-300);
+    margin-bottom: var(--spacing-300);
 }
 
 .timelineBody {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -213,11 +213,48 @@
 }
 
 #line {
+    position: relative;
+
     width: 95%;
-    border-left: 10px solid orange;
     margin-left: 5%;
     margin-bottom: var(--spacing-600);
+
     box-sizing: border-box;
+    border-left: none;
+}
+
+#line::before {
+    content: '';
+    position: absolute;
+
+    width: 5px;
+
+    background: #FFA100;
+
+    left: -9px;
+    top: 38px;
+    bottom: 40px;
+
+    z-index: 1;
+}
+
+#line::after {
+    content: '';
+    position: absolute;
+
+    width: 16px;
+    height: 16px;
+
+    border-left: 4px solid #FFA100;
+    border-top: 4px solid #FFA100;
+
+    left: -14.5px;
+    top: 28px;
+
+    transform: rotate(45deg);
+
+    box-sizing: border-box;
+    z-index: 2;
 }
 
 #History {
@@ -318,9 +355,13 @@
     cursor: pointer;
     user-select: none;
 
-    min-height: 48px;
-    padding: 0 var(--spacing-300);
+    min-height: 64px;
+    padding: 0 16px;
     margin-bottom: 0;
+}
+
+.timelineHeader .yearh1::before {
+    display: none;
 }
 
 .timelineBody {
@@ -331,21 +372,50 @@
     font-size: 1.5rem;
     color: var(--primary-color);
 }
+
 .timelineCard {
-    width: calc(100% - var(--spacing-400));
+    position: relative;
+
+    width: calc(100% - (2 * var(--spacing-400)));
     box-sizing: border-box;
 
     margin-left: var(--spacing-400);
-    margin-bottom: var(--spacing-400);
+    margin-bottom: 20px;
 
-    padding: var(--spacing-400);
+    padding: 0 24px;
 
-    background: var(--background);
+    min-height: 64px;
+
+    background: #2B516A;
 
     border-radius: var(--corner-radius-web);
     outline: var(--thickness-web) solid var(--black);
 
     box-shadow: 6px 6px #121212;
+}
+
+.timelineCard::before {
+    content: '';
+    position: absolute;
+
+    width: 28px;
+    height: 28px;
+
+    border: 4px solid #FFA100;
+    border-radius: 50%;
+
+    background: var(--background);
+
+    left: -45px;
+    top: 50%;
+    transform: translateY(-50%);
+
+    box-sizing: border-box;
+    z-index: 2;
+}
+
+.timelineCard:first-child::before {
+    display: none;
 }
 
 .chevron {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -26,7 +26,7 @@
     padding: 1.2rem;
     width: 30%;
 
-    @media (min-width: 1400px) and (max-width: 2004px) {
+    @media (min-width: breakpoint(xxl)) and (max-width: 2004px) {
         width: 40%;
     }
 
@@ -79,15 +79,19 @@
 
 .headergrid {
     display: grid;
-    grid-template-columns: 25% 25% 25% 25%;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 32px;
+    padding: 0 64px;
     grid-template-rows: 1;
 
     @media (max-width: breakpoint(md)) {
         grid-template-columns: 50% 50%;
+        padding: 0 24px;
     }
 
     @media (max-width: breakpoint(sm)) {
         grid-template-columns: 50% 50%;
+        padding: 0 16px;
     }
 }
 
@@ -154,9 +158,14 @@
 }
 
 .sValues {
-    font: var(font-sw-xl);
+    font: var(--font-sw-xxl);
+    color: #FFA100;
+    font-weight: 400;
+    line-height: 100%;
+    letter-spacing: -0.04em;
     text-align: center;
-    padding: 1%;
+    padding: 0;
+    margin: 0 0 2px;
 }
 .yearh1 {
     font: var(--font-sw-xl);
@@ -351,7 +360,31 @@
 }
 
 .statItem {
-    background: var(--background);
+    background: #2B516A;
     border: 2px solid var(--black);
     border-radius: var(--corner-radius-web);
+    padding: 6px 8px;
+    min-height: 68px;
+    box-sizing: border-box;
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+}
+
+.statItem .gridp {
+    font: var(--font-dm-bold-s);
+    font-size: 12px;
+    line-height: 1.2;
+    text-align: center;
+    padding: 0;
+    margin: 0;
+}
+
+.statsTitle {
+    font: var(--font-sw-l);
+    color: var(--primary-color);
+    text-align: center;
+    margin: 0;
 }

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -134,9 +134,7 @@
     aspect-ratio: 16 / 9;
     border-radius: var(--corner-radius-web);
     overflow: hidden;
-    outline: 4px solid var(--black);
-    box-shadow: 6px 6px #121212;
-    margin: -16px 0 var(--spacing-400) 0;
+    margin: 0 0 var(--spacing-400) 0;
 
     @media (max-width: breakpoint(sm)) {
         max-width: none;
@@ -524,7 +522,66 @@
 }
 
 .timelineBody {
+    display: grid;
+    grid-template-rows: 0fr;
     width: 100%;
+
+    opacity: 0;
+
+    transition:
+        grid-template-rows 0.3s ease,
+        opacity 0.2s ease;
+}
+
+.timelineBodyOpen {
+    grid-template-rows: 1fr;
+    opacity: 1;
+}
+
+.timelineBodyInner {
+    min-height: 0;
+    overflow: hidden;
+}
+
+.timelineCloseArea {
+    width: 100%;
+    padding-top: var(--spacing-400);
+    padding-bottom: var(--spacing-400);
+
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+}
+
+.timelineDivider {
+    width: 100%;
+    height: 4px;
+    background: #FFA100;
+    margin-bottom: var(--spacing-400);
+}
+
+.timelineCloseButton {
+    width: 250px;
+    min-height: 40px;
+
+    padding: 6px 24px;
+
+    background: #FFA100;
+    color: #121212;
+
+    border: var(--thickness-web) solid #121212;
+    border-radius: 999px;
+
+    box-shadow: 4px 4px #121212;
+
+    font: var(--font-dm-bold-s);
+    cursor: pointer;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    box-sizing: border-box;
 }
 
 .timelineCard {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -92,22 +92,10 @@
 }
 
 .storygrid {
-    display: grid;
-    grid-template-columns: 25% 73%;
-    grid-template-rows: 6;
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-400);
     white-space: pre-line;
-
-    @media (max-width: breakpoint(xl)) {
-        grid-template-columns: 35% 65%;
-    }
-
-    @media (max-width: breakpoint(md)) {
-        grid-template-columns: 30% 70%;
-    }
-
-    @media (max-width: breakpoint(sm)) {
-        grid-template-columns: 100%;
-    }
 }
 
 .yearImgWrap {
@@ -250,4 +238,74 @@
     @media (max-width: breakpoint(xxl)) {
         padding-left: var(--spacing-md);
     }
+}
+
+.sortContainer {
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    gap: var(--spacing-sm);
+    margin-bottom: var(--spacing-400);
+    padding-right: var(--spacing-400);
+}
+
+.sortContainer select {
+    padding: 0.4rem 0.8rem;
+    border-radius: var(--corner-radius-web);
+    border: 2px solid var(--black);
+    background: var(--background);
+    cursor: pointer;
+}
+
+.timelineHeader {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+
+    cursor: pointer;
+    user-select: none;
+    padding: var(--spacing-300) 0;
+}
+
+.timelineBody {
+    width: 100%;
+}
+
+.chevron {
+    font-size: 1.5rem;
+    color: var(--primary-color);
+}
+.timelineCard {
+    width: 100%;
+    margin-bottom: var(--spacing-400);
+    padding: var(--spacing-400);
+
+    background: var(--background);
+
+    border-radius: var(--corner-radius-web);
+    outline: var(--thickness-web) solid var(--black);
+
+    box-shadow: 6px 6px #121212;
+}
+
+.chevron {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    margin-left: 1rem;
+    width: 24px;
+    height: 24px;
+
+    transform: rotate(0deg);
+    transition: transform 0.3s ease;
+
+    img {
+        width: 100%;
+        height: 100%;
+    }
+}
+
+.chevronOpen {
+    transform: rotate(180deg);
 }

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.module.scss
@@ -677,6 +677,10 @@
     justify-content: center;
 
     box-sizing: border-box;
+
+    @media (max-width: 400px) {
+        width: calc(100% - 16px);
+    }
 }
 
 .timelineCard {

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -94,31 +94,32 @@ const About = (props: Props) => {
                     </div>
                 </div>
 
-                <div className={cls.containerBottom}>
-                    <div className={cls.sortContainer}>
-                        <DropdownWrapper
-                            dynamicTitle="Järjestä"
-                            showArrow
-                            autoClose
-                            className={cls.timelineSortDropdown}
-                            headerClassName={cls.timelineSortHeader}
-                            contentClassName={cls.timelineSortContent}
-                            contentItemClassName={cls.timelineSortItem}
-                            elements={[
-                                {
-                                    elementText: 'Uusin ensin',
-                                    active: sortOrder === 'desc',
-                                    onClickCallback: () => setSortOrder('desc'),
-                                },
-                                {
-                                    elementText: 'Vanhin ensin',
-                                    active: sortOrder === 'asc',
-                                    onClickCallback: () => setSortOrder('asc'),
-                                },
-                            ]}
-                        />
-                    </div>
+                <div className={cls.sortContainer}>
+                    <DropdownWrapper
+                        dynamicTitle="Järjestä"
+                        showArrow
+                        autoClose
+                        className={cls.timelineSortDropdown}
+                        headerClassName={cls.timelineSortHeader}
+                        contentClassName={cls.timelineSortContent}
+                        contentItemClassName={cls.timelineSortItem}
+                        activeItemClassName={cls.timelineSortItemActive}
+                        elements={[
+                            {
+                                elementText: 'Uusin ensin',
+                                active: sortOrder === 'desc',
+                                onClickCallback: () => setSortOrder('desc'),
+                            },
+                            {
+                                elementText: 'Vanhin ensin',
+                                active: sortOrder === 'asc',
+                                onClickCallback: () => setSortOrder('asc'),
+                            },
+                        ]}
+                    />
+                </div>
 
+                <div className={cls.containerBottom}>
                     <div
                         className={`${cls.storygrid} ${
                             sortOrder === 'desc' ? cls.timelineNewest : cls.timelineOldest

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -27,8 +27,6 @@ export interface Props {
 const About = (props: Props) => {
     const {
         title,
-        description,
-        keywords,
         storytitle,
         project,
         locality,
@@ -67,7 +65,7 @@ const About = (props: Props) => {
                 </p>
 
                 <div className={cls.containerTop}>
-                    <p className={cls.h1}>{title}</p>
+                    <p className={cls.statsTitle}>{title}</p>
 
                     <div className={cls.headergrid}>
                         <div className={cls.statItem}>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -47,6 +47,10 @@ const About = (props: Props) => {
 
     const { t } = useClientTranslation('about');
 
+    const designers = t('designer.names', {
+        returnObjects: true,
+    }) as { name: string; url: string }[];
+
     const { data: projectCount = 0, isLoading: membersLoading } = useGetMembersCountQuery();
 
     const {
@@ -151,6 +155,24 @@ const About = (props: Props) => {
                             V2026={V2026}
                         />
                     </div>
+                </div>
+
+                <div className={cls.designerContainer}>
+                    <p className={cls.designerText}>
+                        {t('designer.label')}{' '}
+                        {designers.map((designer, index) => (
+                            <span key={designer.name}>
+                                {index > 0 && ', '}
+                                <a
+                                    href={designer.url}
+                                    target="_blank"
+                                    rel="noopener noreferrer"
+                                >
+                                    {designer.name}
+                                </a>
+                            </span>
+                        ))}
+                    </p>
                 </div>
             </div>
         </main>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -69,31 +69,27 @@ const About = (props: Props) => {
                 <div className={cls.containerTop}>
                     <p className={cls.h1}>{title}</p>
 
-                    <p className={cls.gridp}>{description}</p>
-
-                    <p className={cls.h1}>{keywords}</p>
-
                     <div className={cls.headergrid}>
-                        <div>
+                        <div className={cls.statItem}>
                             <p className={cls.sValues}>{isLoading ? '...' : projectCount}</p>
                             <p className={cls.gridp}>{project}</p>
                         </div>
 
-                        <div>
+                        <div className={cls.statItem}>
                             <p className={cls.sValues}>
                                 {isLoading ? '...' : demographics.localities}
                             </p>
                             <p className={cls.gridp}>{locality}</p>
                         </div>
 
-                        <div>
+                        <div className={cls.statItem}>
                             <p className={cls.sValues}>
                                 {isLoading ? '...' : demographics.nationalities}
                             </p>
                             <p className={cls.gridp}>{nationality}</p>
                         </div>
 
-                        <div>
+                        <div className={cls.statItem}>
                             <p className={cls.sValues}>{behindCount}</p>
                             <p className={cls.gridp}>{behind}</p>
                         </div>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -1,15 +1,9 @@
 'use client';
 import cls from './About.module.scss';
-import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 import Image from 'next/image';
 import heroTop from '@/shared/assets/images/aboutPage/hero-top.png';
-import img2019 from '@/shared/assets/images/aboutPage/about2019.png';
-import img2020 from '@/shared/assets/images/aboutPage/about2020.png';
-import img2021 from '@/shared/assets/images/aboutPage/about2021.png';
-import img2022 from '@/shared/assets/images/aboutPage/about2022.png';
-import img2023 from '@/shared/assets/images/aboutPage/about2023.png';
-import img2024 from '@/shared/assets/images/aboutPage/about2024.png';
 import { useGetMembersCountQuery, useGetDemographicsQuery, getBehindYears } from '@/entities/About';
+import Timeline from './Timeline';
 
 export interface Props {
     title: string;
@@ -51,6 +45,7 @@ const About = (props: Props) => {
     } = props;
 
     const { data: projectCount = 0, isLoading: membersLoading } = useGetMembersCountQuery();
+
     const {
         data: demographics = { localities: 0, nationalities: 0 },
         isLoading: demographicsLoading,
@@ -74,142 +69,60 @@ const About = (props: Props) => {
                     sizes="100vw"
                 />
             </section>
+
             <div className={cls.containerTop}>
-                <p className={`${cls.h1}`}>{title}</p>
+                <p className={cls.h1}>{title}</p>
+
                 <p className={cls.gridp}>{description}</p>
-                <p className={`${cls.h1}`}>{keywords}</p>
+
+                <p className={cls.h1}>{keywords}</p>
+
                 <div className={cls.headergrid}>
                     <div>
                         <p className={cls.sValues}>{isLoading ? '...' : projectCount}</p>
                         <p className={cls.gridp}>{project}</p>
                     </div>
+
                     <div>
                         <p className={cls.sValues}>{isLoading ? '...' : demographics.localities}</p>
                         <p className={cls.gridp}>{locality}</p>
                     </div>
+
                     <div>
                         <p className={cls.sValues}>
                             {isLoading ? '...' : demographics.nationalities}
                         </p>
                         <p className={cls.gridp}>{nationality}</p>
                     </div>
+
                     <div>
                         <p className={cls.sValues}>{behindCount}</p>
                         <p className={cls.gridp}>{behind}</p>
                     </div>
                 </div>
             </div>
+
             <div className={cls.containerBottom}>
                 <p
-                    className={`${cls.h1}`}
+                    className={cls.h1}
                     id={cls.History}
                 >
                     {storytitle}
                 </p>
+
                 <div
                     className={cls.storygrid}
                     id={cls.line}
                 >
-                    <p className={cls.yearh1}>2019</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2019}
-                                alt="2019 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2019}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2020</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2020}
-                                alt="2020 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2020}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2021</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2021}
-                                alt="2021 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2021}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2022</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2022}
-                                alt="2022 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2022}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2023</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2023}
-                                alt="2023 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2023}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2024</p>
-                    <div>
-                        <div className={cls.yearImgWrap}>
-                            <Image
-                                src={img2024}
-                                alt="2024 year image"
-                                fill
-                                className={cls.yearImg}
-                                sizes="(max-width: 768px) 94vw, 34vw"
-                            />
-                        </div>
-                        <p className={cls.p}>{V2024}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2025</p>
-                    <div>
-                        <p className={cls.p}>{V2025}</p>
-                    </div>
-
-                    <p className={cls.yearh1}>2026</p>
-                    <div>
-                        <p className={cls.p}>{V2026}</p>
-                    </div>
-
-                    <Image
-                        loading="eager"
-                        alt={'Chevron'}
-                        src={chevronDown}
-                        className={cls.chevronImage}
-                        width={50}
+                    <Timeline
+                        V2019={V2019}
+                        V2020={V2020}
+                        V2021={V2021}
+                        V2022={V2022}
+                        V2023={V2023}
+                        V2024={V2024}
+                        V2025={V2025}
+                        V2026={V2026}
                     />
                 </div>
             </div>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -109,12 +109,12 @@ const About = (props: Props) => {
                         chevronClassName={cls.timelineSortChevron}
                         elements={[
                             {
-                                elementText: 'Uusin ensin',
+                                elementText: 'Uusin',
                                 active: sortOrder === 'desc',
                                 onClickCallback: () => setSortOrder('desc'),
                             },
                             {
-                                elementText: 'Vanhin ensin',
+                                elementText: 'Vanhin',
                                 active: sortOrder === 'asc',
                                 onClickCallback: () => setSortOrder('asc'),
                             },

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -100,13 +100,19 @@ const About = (props: Props) => {
                             dynamicTitle="Järjestä"
                             showArrow
                             autoClose
+                            className={cls.timelineSortDropdown}
+                            headerClassName={cls.timelineSortHeader}
+                            contentClassName={cls.timelineSortContent}
+                            contentItemClassName={cls.timelineSortItem}
                             elements={[
                                 {
                                     elementText: 'Uusin ensin',
+                                    active: sortOrder === 'desc',
                                     onClickCallback: () => setSortOrder('desc'),
                                 },
                                 {
                                     elementText: 'Vanhin ensin',
+                                    active: sortOrder === 'asc',
                                     onClickCallback: () => setSortOrder('asc'),
                                 },
                             ]}
@@ -114,7 +120,9 @@ const About = (props: Props) => {
                     </div>
 
                     <div
-                        className={cls.storygrid}
+                        className={`${cls.storygrid} ${
+                            sortOrder === 'desc' ? cls.timelineNewest : cls.timelineOldest
+                        }`}
                         id={cls.line}
                     >
                         <Timeline

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -58,79 +58,83 @@ const About = (props: Props) => {
 
     return (
         <main className={cls.main}>
-            <p
-                className={cls.h1}
-                id={cls.History}
-            >
-                {storytitle}
-            </p>
-
-            <div className={cls.containerTop}>
-                <p className={cls.h1}>{title}</p>
-
-                <p className={cls.gridp}>{description}</p>
-
-                <p className={cls.h1}>{keywords}</p>
-
-                <div className={cls.headergrid}>
-                    <div>
-                        <p className={cls.sValues}>{isLoading ? '...' : projectCount}</p>
-                        <p className={cls.gridp}>{project}</p>
-                    </div>
-
-                    <div>
-                        <p className={cls.sValues}>{isLoading ? '...' : demographics.localities}</p>
-                        <p className={cls.gridp}>{locality}</p>
-                    </div>
-
-                    <div>
-                        <p className={cls.sValues}>
-                            {isLoading ? '...' : demographics.nationalities}
-                        </p>
-                        <p className={cls.gridp}>{nationality}</p>
-                    </div>
-
-                    <div>
-                        <p className={cls.sValues}>{behindCount}</p>
-                        <p className={cls.gridp}>{behind}</p>
-                    </div>
-                </div>
-            </div>
-
-            <div className={cls.containerBottom}>
-                <div className={cls.sortContainer}>
-                    <DropdownWrapper
-                        dynamicTitle="Järjestä"
-                        showArrow
-                        autoClose
-                        elements={[
-                            {
-                                elementText: 'Uusin ensin',
-                                onClickCallback: () => setSortOrder('desc'),
-                            },
-                            {
-                                elementText: 'Vanhin ensin',
-                                onClickCallback: () => setSortOrder('asc'),
-                            },
-                        ]}
-                    />
-                </div>
-
-                <div
-                    className={cls.storygrid}
-                    id={cls.line}
+            <div className={cls.aboutContent}>
+                <p
+                    className={cls.h1}
+                    id={cls.History}
                 >
-                    <Timeline
-                        sortOrder={sortOrder}
-                        V2019={V2019}
-                        V2020={V2020}
-                        V2021={V2021}
-                        V2022={V2022}
-                        V2023={V2023}
-                        V2024={V2024}
-                        V2025={V2025}
-                        V2026={V2026}
-                    />
+                    {storytitle}
+                </p>
+
+                <div className={cls.containerTop}>
+                    <p className={cls.h1}>{title}</p>
+
+                    <p className={cls.gridp}>{description}</p>
+
+                    <p className={cls.h1}>{keywords}</p>
+
+                    <div className={cls.headergrid}>
+                        <div>
+                            <p className={cls.sValues}>{isLoading ? '...' : projectCount}</p>
+                            <p className={cls.gridp}>{project}</p>
+                        </div>
+
+                        <div>
+                            <p className={cls.sValues}>
+                                {isLoading ? '...' : demographics.localities}
+                            </p>
+                            <p className={cls.gridp}>{locality}</p>
+                        </div>
+
+                        <div>
+                            <p className={cls.sValues}>
+                                {isLoading ? '...' : demographics.nationalities}
+                            </p>
+                            <p className={cls.gridp}>{nationality}</p>
+                        </div>
+
+                        <div>
+                            <p className={cls.sValues}>{behindCount}</p>
+                            <p className={cls.gridp}>{behind}</p>
+                        </div>
+                    </div>
+                </div>
+
+                <div className={cls.containerBottom}>
+                    <div className={cls.sortContainer}>
+                        <DropdownWrapper
+                            dynamicTitle="Järjestä"
+                            showArrow
+                            autoClose
+                            elements={[
+                                {
+                                    elementText: 'Uusin ensin',
+                                    onClickCallback: () => setSortOrder('desc'),
+                                },
+                                {
+                                    elementText: 'Vanhin ensin',
+                                    onClickCallback: () => setSortOrder('asc'),
+                                },
+                            ]}
+                        />
+                    </div>
+
+                    <div
+                        className={cls.storygrid}
+                        id={cls.line}
+                    >
+                        <Timeline
+                            sortOrder={sortOrder}
+                            V2019={V2019}
+                            V2020={V2020}
+                            V2021={V2021}
+                            V2022={V2022}
+                            V2023={V2023}
+                            V2024={V2024}
+                            V2025={V2025}
+                            V2026={V2026}
+                        />
+                    </div>
                 </div>
             </div>
         </main>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -1,9 +1,11 @@
 'use client';
+import Image from 'next/image';
 import { useState } from 'react';
 import cls from './About.module.scss';
 import { useGetMembersCountQuery, useGetDemographicsQuery, getBehindYears } from '@/entities/About';
 import { DropdownWrapper } from '@/shared/ui/DropdownWrapperV2/ui/DropdownWrapper';
 import Timeline from './Timeline';
+import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 
 export interface Props {
     title: string;
@@ -126,6 +128,13 @@ const About = (props: Props) => {
                         }`}
                         id={cls.line}
                     >
+                        <Image
+                            src={chevronDown}
+                            alt=""
+                            aria-hidden="true"
+                            className={cls.timelineChevron}
+                        />
+
                         <Timeline
                             sortOrder={sortOrder}
                             V2019={V2019}

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -73,14 +73,14 @@ const About = (props: Props) => {
                             <p className={cls.gridp}>{project}</p>
                         </div>
 
-                        <div className={cls.statItem}>
+                        <div className={`${cls.statItem} ${cls.statItemNarrow}`}>
                             <p className={cls.sValues}>
                                 {isLoading ? '...' : demographics.localities}
                             </p>
                             <p className={cls.gridp}>{locality}</p>
                         </div>
 
-                        <div className={cls.statItem}>
+                        <div className={`${cls.statItem} ${cls.statItemNarrow}`}>
                             <p className={cls.sValues}>
                                 {isLoading ? '...' : demographics.nationalities}
                             </p>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -10,8 +10,6 @@ import { useClientTranslation } from '@/shared/i18n';
 
 export interface Props {
     title: string;
-    description: string;
-    keywords: string;
     storytitle: string;
     project: string;
     locality: string;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -106,6 +106,7 @@ const About = (props: Props) => {
                         contentClassName={cls.timelineSortContent}
                         contentItemClassName={cls.timelineSortItem}
                         activeItemClassName={cls.timelineSortItemActive}
+                        chevronClassName={cls.timelineSortChevron}
                         elements={[
                             {
                                 elementText: 'Uusin ensin',

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -6,6 +6,7 @@ import { useGetMembersCountQuery, useGetDemographicsQuery, getBehindYears } from
 import { DropdownWrapper } from '@/shared/ui/DropdownWrapperV2/ui/DropdownWrapper';
 import Timeline from './Timeline';
 import chevronDown from '@/shared/assets/icons/chevronDown.svg';
+import { useClientTranslation } from '@/shared/i18n';
 
 export interface Props {
     title: string;
@@ -43,6 +44,8 @@ const About = (props: Props) => {
         V2025,
         V2026,
     } = props;
+
+    const { t } = useClientTranslation('about');
 
     const { data: projectCount = 0, isLoading: membersLoading } = useGetMembersCountQuery();
 
@@ -98,7 +101,7 @@ const About = (props: Props) => {
 
                 <div className={cls.sortContainer}>
                     <DropdownWrapper
-                        dynamicTitle="Järjestä"
+                        dynamicTitle={t('timeline.sort')}
                         showArrow
                         autoClose
                         className={cls.timelineSortDropdown}
@@ -106,15 +109,15 @@ const About = (props: Props) => {
                         contentClassName={cls.timelineSortContent}
                         contentItemClassName={cls.timelineSortItem}
                         activeItemClassName={cls.timelineSortItemActive}
-                        chevronClassName={cls.timelineSortChevron}
+                        chevronWrapperClassName={cls.timelineSortChevronWrapper}
                         elements={[
                             {
-                                elementText: 'Uusin',
+                                elementText: t('timeline.newest'),
                                 active: sortOrder === 'desc',
                                 onClickCallback: () => setSortOrder('desc'),
                             },
                             {
-                                elementText: 'Vanhin',
+                                elementText: t('timeline.oldest'),
                                 active: sortOrder === 'asc',
                                 onClickCallback: () => setSortOrder('asc'),
                             },

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/About.tsx
@@ -1,8 +1,8 @@
 'use client';
+import { useState } from 'react';
 import cls from './About.module.scss';
-import Image from 'next/image';
-import heroTop from '@/shared/assets/images/aboutPage/hero-top.png';
 import { useGetMembersCountQuery, useGetDemographicsQuery, getBehindYears } from '@/entities/About';
+import { DropdownWrapper } from '@/shared/ui/DropdownWrapperV2/ui/DropdownWrapper';
 import Timeline from './Timeline';
 
 export interface Props {
@@ -54,21 +54,16 @@ const About = (props: Props) => {
     const behindCount = getBehindYears();
     const isLoading = membersLoading || demographicsLoading;
 
+    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
     return (
         <main className={cls.main}>
-            <section
-                className={cls.hero}
-                aria-label="About hero image"
+            <p
+                className={cls.h1}
+                id={cls.History}
             >
-                <Image
-                    src={heroTop}
-                    alt="Hero Image"
-                    fill
-                    priority
-                    className={cls.heroImg}
-                    sizes="100vw"
-                />
-            </section>
+                {storytitle}
+            </p>
 
             <div className={cls.containerTop}>
                 <p className={cls.h1}>{title}</p>
@@ -103,18 +98,30 @@ const About = (props: Props) => {
             </div>
 
             <div className={cls.containerBottom}>
-                <p
-                    className={cls.h1}
-                    id={cls.History}
-                >
-                    {storytitle}
-                </p>
+                <div className={cls.sortContainer}>
+                    <DropdownWrapper
+                        dynamicTitle="Järjestä"
+                        showArrow
+                        autoClose
+                        elements={[
+                            {
+                                elementText: 'Uusin ensin',
+                                onClickCallback: () => setSortOrder('desc'),
+                            },
+                            {
+                                elementText: 'Vanhin ensin',
+                                onClickCallback: () => setSortOrder('asc'),
+                            },
+                        ]}
+                    />
+                </div>
 
                 <div
                     className={cls.storygrid}
                     id={cls.line}
                 >
                     <Timeline
+                        sortOrder={sortOrder}
                         V2019={V2019}
                         V2020={V2020}
                         V2021={V2021}

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
@@ -43,12 +43,15 @@ const Timeline = ({ sortOrder, V2019, V2020, V2021, V2022, V2023, V2024, V2025, 
 
     return (
         <>
-            {sortedTimeline.map((item) => (
+            {sortedTimeline.map((item, index) => (
                 <TimelineEntry
                     key={item.year}
                     year={item.year}
                     text={item.text}
                     image={item.image}
+                    sortOrder={sortOrder}
+                    isFirst={index === 0}
+                    isLast={index === sortedTimeline.length - 1}
                 />
             ))}
         </>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
@@ -1,17 +1,14 @@
-import Image, { StaticImageData } from 'next/image';
-import chevronDown from '@/shared/assets/icons/chevronDown.svg';
+import { StaticImageData } from 'next/image';
 import img2019 from '@/shared/assets/images/aboutPage/about2019.png';
 import img2020 from '@/shared/assets/images/aboutPage/about2020.png';
 import img2021 from '@/shared/assets/images/aboutPage/about2021.png';
 import img2022 from '@/shared/assets/images/aboutPage/about2022.png';
 import img2023 from '@/shared/assets/images/aboutPage/about2023.png';
 import img2024 from '@/shared/assets/images/aboutPage/about2024.png';
-import cls from './About.module.scss';
 import TimelineEntry from './TimelineEntry';
 
 interface Props {
     sortOrder: 'asc' | 'desc';
-
     V2019: string;
     V2020: string;
     V2021: string;
@@ -54,14 +51,6 @@ const Timeline = ({ sortOrder, V2019, V2020, V2021, V2022, V2023, V2024, V2025, 
                     image={item.image}
                 />
             ))}
-
-            <Image
-                loading="eager"
-                alt="Chevron"
-                src={chevronDown}
-                className={cls.chevronImage}
-                width={50}
-            />
         </>
     );
 };

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import Image, { StaticImageData } from 'next/image';
 import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 import img2019 from '@/shared/assets/images/aboutPage/about2019.png';
@@ -38,9 +39,28 @@ const Timeline = ({ V2019, V2020, V2021, V2022, V2023, V2024, V2025, V2026 }: Pr
         { year: 2026, image: null, text: V2026 },
     ];
 
+    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
+
+    const sortedTimeline = [...timeline].sort((a, b) =>
+        sortOrder === 'desc' ? b.year - a.year : a.year - b.year,
+    );
+
     return (
         <>
-            {timeline.map((item) => (
+            <div className={cls.sortContainer}>
+                <label htmlFor="timeline-sort">Sort by: </label>
+
+                <select
+                    id="timeline-sort"
+                    value={sortOrder}
+                    onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
+                >
+                    <option value="asc">Oldest first</option>
+                    <option value="desc">Newest first</option>
+                </select>
+            </div>
+
+            {sortedTimeline.map((item) => (
                 <TimelineEntry
                     key={item.year}
                     year={item.year}

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
@@ -1,0 +1,63 @@
+import Image, { StaticImageData } from 'next/image';
+import chevronDown from '@/shared/assets/icons/chevronDown.svg';
+import img2019 from '@/shared/assets/images/aboutPage/about2019.png';
+import img2020 from '@/shared/assets/images/aboutPage/about2020.png';
+import img2021 from '@/shared/assets/images/aboutPage/about2021.png';
+import img2022 from '@/shared/assets/images/aboutPage/about2022.png';
+import img2023 from '@/shared/assets/images/aboutPage/about2023.png';
+import img2024 from '@/shared/assets/images/aboutPage/about2024.png';
+import cls from './About.module.scss';
+import TimelineEntry from './TimelineEntry';
+
+interface Props {
+    V2019: string;
+    V2020: string;
+    V2021: string;
+    V2022: string;
+    V2023: string;
+    V2024: string;
+    V2025: string;
+    V2026: string;
+}
+
+interface TimelineItem {
+    year: number;
+    text: string;
+    image: StaticImageData | null;
+}
+
+const Timeline = ({ V2019, V2020, V2021, V2022, V2023, V2024, V2025, V2026 }: Props) => {
+    const timeline: TimelineItem[] = [
+        { year: 2019, image: img2019, text: V2019 },
+        { year: 2020, image: img2020, text: V2020 },
+        { year: 2021, image: img2021, text: V2021 },
+        { year: 2022, image: img2022, text: V2022 },
+        { year: 2023, image: img2023, text: V2023 },
+        { year: 2024, image: img2024, text: V2024 },
+        { year: 2025, image: null, text: V2025 },
+        { year: 2026, image: null, text: V2026 },
+    ];
+
+    return (
+        <>
+            {timeline.map((item) => (
+                <TimelineEntry
+                    key={item.year}
+                    year={item.year}
+                    text={item.text}
+                    image={item.image}
+                />
+            ))}
+
+            <Image
+                loading="eager"
+                alt="Chevron"
+                src={chevronDown}
+                className={cls.chevronImage}
+                width={50}
+            />
+        </>
+    );
+};
+
+export default Timeline;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/Timeline.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react';
 import Image, { StaticImageData } from 'next/image';
 import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 import img2019 from '@/shared/assets/images/aboutPage/about2019.png';
@@ -11,6 +10,8 @@ import cls from './About.module.scss';
 import TimelineEntry from './TimelineEntry';
 
 interface Props {
+    sortOrder: 'asc' | 'desc';
+
     V2019: string;
     V2020: string;
     V2021: string;
@@ -27,7 +28,7 @@ interface TimelineItem {
     image: StaticImageData | null;
 }
 
-const Timeline = ({ V2019, V2020, V2021, V2022, V2023, V2024, V2025, V2026 }: Props) => {
+const Timeline = ({ sortOrder, V2019, V2020, V2021, V2022, V2023, V2024, V2025, V2026 }: Props) => {
     const timeline: TimelineItem[] = [
         { year: 2019, image: img2019, text: V2019 },
         { year: 2020, image: img2020, text: V2020 },
@@ -39,27 +40,12 @@ const Timeline = ({ V2019, V2020, V2021, V2022, V2023, V2024, V2025, V2026 }: Pr
         { year: 2026, image: null, text: V2026 },
     ];
 
-    const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('desc');
-
     const sortedTimeline = [...timeline].sort((a, b) =>
         sortOrder === 'desc' ? b.year - a.year : a.year - b.year,
     );
 
     return (
         <>
-            <div className={cls.sortContainer}>
-                <label htmlFor="timeline-sort">Sort by: </label>
-
-                <select
-                    id="timeline-sort"
-                    value={sortOrder}
-                    onChange={(e) => setSortOrder(e.target.value as 'asc' | 'desc')}
-                >
-                    <option value="asc">Oldest first</option>
-                    <option value="desc">Newest first</option>
-                </select>
-            </div>
-
             {sortedTimeline.map((item) => (
                 <TimelineEntry
                     key={item.year}

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -1,4 +1,6 @@
+import { useState } from 'react';
 import Image, { StaticImageData } from 'next/image';
+import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 import cls from './About.module.scss';
 
 interface TimelineEntryProps {
@@ -8,26 +10,44 @@ interface TimelineEntryProps {
 }
 
 const TimelineEntry = ({ year, text, image }: TimelineEntryProps) => {
+    const [isOpen, setIsOpen] = useState(false);
+
     return (
-        <>
-            <p className={cls.yearh1}>{year}</p>
+        <div className={cls.timelineCard}>
+            <div
+                className={cls.timelineHeader}
+                onClick={() => setIsOpen(!isOpen)}
+            >
+                <p className={cls.yearh1}>{year}</p>
 
-            <div>
-                {image && (
-                    <div className={cls.yearImgWrap}>
-                        <Image
-                            src={image}
-                            alt={`${year} year image`}
-                            fill
-                            className={cls.yearImg}
-                            sizes="(max-width: 768px) 94vw, 34vw"
-                        />
-                    </div>
-                )}
-
-                <p className={cls.p}>{text}</p>
+                <Image
+                    src={chevronDown}
+                    alt=""
+                    width={20}
+                    height={20}
+                    aria-hidden="true"
+                    className={`${cls.chevron} ${isOpen ? cls.chevronOpen : ''}`}
+                />
             </div>
-        </>
+
+            {isOpen && (
+                <div className={cls.timelineBody}>
+                    {image && (
+                        <div className={cls.yearImgWrap}>
+                            <Image
+                                src={image}
+                                alt={`${year} year image`}
+                                fill
+                                className={cls.yearImg}
+                                sizes="(max-width: 768px) 94vw, 34vw"
+                            />
+                        </div>
+                    )}
+
+                    <p className={cls.p}>{text}</p>
+                </div>
+            )}
+        </div>
     );
 };
 

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -37,8 +37,8 @@ const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: Timeli
                 />
             </div>
 
-            {isOpen && (
-                <div className={cls.timelineBody}>
+            <div className={`${cls.timelineBody} ${isOpen ? cls.timelineBodyOpen : ''}`}>
+                <div className={cls.timelineBodyInner}>
                     {image && (
                         <div className={cls.yearImgWrap}>
                             <Image
@@ -52,8 +52,20 @@ const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: Timeli
                     )}
 
                     <p className={cls.p}>{text}</p>
+
+                    <div className={cls.timelineCloseArea}>
+                        <div className={cls.timelineDivider} />
+
+                        <button
+                            type="button"
+                            className={cls.timelineCloseButton}
+                            onClick={() => setIsOpen(false)}
+                        >
+                            Sulje
+                        </button>
+                    </div>
                 </div>
-            )}
+            </div>
         </div>
     );
 };

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react';
 import Image, { StaticImageData } from 'next/image';
 import chevronDown from '@/shared/assets/icons/chevronDown.svg';
 import cls from './About.module.scss';
+import { useClientTranslation } from '@/shared/i18n';
 
 interface TimelineEntryProps {
     year: number;
@@ -14,6 +15,7 @@ interface TimelineEntryProps {
 
 const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: TimelineEntryProps) => {
     const [isOpen, setIsOpen] = useState(false);
+    const { t } = useClientTranslation('about');
 
     return (
         <div
@@ -67,7 +69,7 @@ const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: Timeli
                             className={cls.timelineCloseButton}
                             onClick={() => setIsOpen(false)}
                         >
-                            Sulje
+                            {t('timeline.close')}
                         </button>
                     </div>
                 </div>

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -7,13 +7,20 @@ interface TimelineEntryProps {
     year: number;
     text: string;
     image?: StaticImageData | null;
+    sortOrder: 'asc' | 'desc';
+    isFirst: boolean;
+    isLast: boolean;
 }
 
-const TimelineEntry = ({ year, text, image }: TimelineEntryProps) => {
+const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: TimelineEntryProps) => {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-        <div className={cls.timelineCard}>
+        <div
+            className={`${cls.timelineCard} ${
+                isFirst && sortOrder === 'desc' ? cls.timelineStart : ''
+            } ${isLast && sortOrder === 'asc' ? cls.timelineEnd : ''}`}
+        >
             <div
                 className={cls.timelineHeader}
                 onClick={() => setIsOpen(!isOpen)}

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -1,0 +1,34 @@
+import Image, { StaticImageData } from 'next/image';
+import cls from './About.module.scss';
+
+interface TimelineEntryProps {
+    year: number;
+    text: string;
+    image?: StaticImageData | null;
+}
+
+const TimelineEntry = ({ year, text, image }: TimelineEntryProps) => {
+    return (
+        <>
+            <p className={cls.yearh1}>{year}</p>
+
+            <div>
+                {image && (
+                    <div className={cls.yearImgWrap}>
+                        <Image
+                            src={image}
+                            alt={`${year} year image`}
+                            fill
+                            className={cls.yearImg}
+                            sizes="(max-width: 768px) 94vw, 34vw"
+                        />
+                    </div>
+                )}
+
+                <p className={cls.p}>{text}</p>
+            </div>
+        </>
+    );
+};
+
+export default TimelineEntry;

--- a/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
+++ b/frontend-next-migration/src/preparedPages/AboutPage/ui/TimelineEntry.tsx
@@ -27,14 +27,20 @@ const TimelineEntry = ({ year, text, image, sortOrder, isFirst, isLast }: Timeli
             >
                 <p className={cls.yearh1}>{year}</p>
 
-                <Image
-                    src={chevronDown}
-                    alt=""
-                    width={20}
-                    height={20}
-                    aria-hidden="true"
-                    className={`${cls.chevron} ${isOpen ? cls.chevronOpen : ''}`}
-                />
+                <span
+                    className={`${cls.timelineChevronWrapper} ${
+                        isOpen ? cls.timelineChevronWrapperOpen : ''
+                    }`}
+                >
+                    <Image
+                        src={chevronDown}
+                        alt=""
+                        width={20}
+                        height={20}
+                        aria-hidden="true"
+                        className={cls.chevron}
+                    />
+                </span>
             </div>
 
             <div className={`${cls.timelineBody} ${isOpen ? cls.timelineBodyOpen : ''}`}>

--- a/frontend-next-migration/src/shared/i18n/locales/en/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/about.json
@@ -16,6 +16,16 @@
         "close": "Close"
     },
 
+    "designer": {
+    "label": "Designed by:",
+    "names": [
+        {
+            "name": "Sanna-Kaisa Mastokangas",
+            "url": "https://piisamisiili.artstation.com/"
+        }
+    ]
+},
+
   "story-title": "ALT Zone's history",
   
   "V2019": "The idea for the ALT Zone mobile game was born from the imagination of an 11-year-old boy. The concept was introduced to Psyche’s Royale Gaming (PRG ry), whose team immediately got excited—this was a unique kind of game we’d want to play ourselves and share with others! What stood out to the PRG team was that instead of relying on the typical fighting and shooting mechanics found in mobile games, ALT Zone’s gameplay would revolve around shielding and defense. These forms of protection would be drawn from real life: the alcoholic’s shield might be a bottle, the know-it-all’s a book, and so on.\n\nSoon, a whole cluster of new, thought-provoking ideas began to take shape around the concept. This raised a question: could the game function as a platform for artistic exploration and reflection on the human condition? What kind of discussion could we spark? At the time, PRG ry was primarily organizing inclusive gaming events and eSports activities, which had already built ties to the professional gaming community. We began pitching the game idea to a number of industry professionals—and they seemed just as excited as we were.\n\nInspired by this, the PRG team began to think more broadly about the potential of games as thought-provoking art—and about the role of games in arts education more generally. How could games be meaningfully integrated into schools alongside theatre, visual arts, literature, and cinema? In arts education, beyond exploring historical movements and examples, a key element often lies in collectively experiencing an artwork and reflecting on its meanings together. But how could this be realized through the medium of games?\n\nIn conversations with game industry professionals, we learned that most of their attempts to introduce game testing in schools had failed—mainly because schools don’t engage in commercial collaborations. PRG ry recognized a chance to bring its expertise in arts education to meet a clear need in the games sector. Before shifting toward game development, PRG had been touring theatre performances in schools—fulfilling a national curriculum requirement to provide all students yearly opportunities to experience and participate in theatre. These performances were followed by classroom-based workshops and discussions.\n\nA new question emerged: what if we brought the ALT Zone mobile game to schools in a similar format, and brought a unified gameplay experience into the classroom—something students could engage with as a shared artistic encounter, either as a singular piece or as part of a broader thematic whole, also enabling the possibility to take part in its further development. After all, PRG ry is a volunteer-based association where people bring their ideas to life without money ever changing hands. The idea felt too compelling to ignore, and a network of professional developers offered to help us figure out how to move forward. It was time to take a leap into the unknown. The work could begin.",

--- a/frontend-next-migration/src/shared/i18n/locales/en/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/about.json
@@ -7,8 +7,8 @@
   "og-description": "PRG ry is a Finnish non-profit association developing the ALT Zone mobile game in collaboration with youth, volunteers, and game industry professionals.",
 
   "project": "Has worked on this project",
-  "locality": "From a different locality",
-  "nationality": "From a different nationality",
+  "locality": "Localities represented",
+  "nationality": "Nationalities represented",
   "behind": "Years into the journey",
 
   "story-title": "ALT Zone's history",

--- a/frontend-next-migration/src/shared/i18n/locales/en/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/about.json
@@ -1,6 +1,6 @@
 {
   "title": "About Us",
-  "head-title": "What is PRG?",
+  "head-title": "A lot of talented people work on this project",
   "head-description": "Psyche's Royale Gaming ry is a non-profit game art association that is collaboratively developing the mobile game ALT Zone 1.0",
   "head-keywords": "ALT Zone, ALT Zone mobile game, community game development, participate in game creation, game art mobile game",
   "og-title": "Psyche's Royale Gaming ry – Creators and Community of ALT Zone Game Art",

--- a/frontend-next-migration/src/shared/i18n/locales/en/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/en/about.json
@@ -5,11 +5,16 @@
   "head-keywords": "ALT Zone, ALT Zone mobile game, community game development, participate in game creation, game art mobile game",
   "og-title": "Psyche's Royale Gaming ry – Creators and Community of ALT Zone Game Art",
   "og-description": "PRG ry is a Finnish non-profit association developing the ALT Zone mobile game in collaboration with youth, volunteers, and game industry professionals.",
-
   "project": "Has worked on this project",
   "locality": "Localities represented",
   "nationality": "Nationalities represented",
   "behind": "Years into the journey",
+  "timeline": {
+        "sort": "Sort by",
+        "newest": "Newest",
+        "oldest": "Oldest",
+        "close": "Close"
+    },
 
   "story-title": "ALT Zone's history",
   

--- a/frontend-next-migration/src/shared/i18n/locales/fi/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/about.json
@@ -9,6 +9,12 @@
     "locality": "Eri paikkakunnalta",
     "nationality": "Eri kansalaisuutta",
     "behind": "Vuotta matkaa takana",
+    "timeline": {
+        "sort": "Järjestä",
+        "newest": "Uusin",
+        "oldest": "Vanhin",
+        "close": "Sulje"
+    },
 
     "story-title": "ALT Zonen historia",
 

--- a/frontend-next-migration/src/shared/i18n/locales/fi/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/about.json
@@ -16,6 +16,16 @@
         "close": "Sulje"
     },
 
+    "designer": {
+    "label": "Sivun suunnitteli:",
+    "names": [
+        {
+            "name": "Sanna-Kaisa Mastokangas",
+            "url": "https://piisamisiili.artstation.com/"
+        }
+    ]
+},
+
     "story-title": "ALT Zonen historia",
 
     "V2019": "ALT Zone -mobiilipelin idea syntyi 11-vuotiaan pojan toimesta. Idea esiteltiin Psyche's Royale Gamingille (PRG ry), jonka tiimi innostui ideasti heti – tässä olisi uniikki peli, jota haluamme itse pelata ja esitellä myös muille! Pelin ideassa PRG-tiimiä kiinnosti erityisesti se, että mobiilipeleille tyypillisten taistelu- ja ammuntamekanismien sijaan pelimekaniikka keskittyisi suojautumiseen. Nämä suojautumistavat olisivat kuin elävästä elämästä: alkoholistilla suojakilpenä toimisi pullo, viisastelijalla kirja, ja niin edelleen.\n\n Pelikonseptin ympärille alkoi pian muodostua kokonainen joukko uusia, ajatuksia herättäviä ideoita. Tämä herätti kysymyksen: voisiko peli toimia alustana taiteelliselle tutkimiselle ja pohdinnalle ihmisyyden kokemuksesta? Minkälaista keskustelua pelin välityksellä voitaisiin synnyttää? Tuohon aikaan, PRG ry toimi ensisijaisesti osallistavien pelitapahtumien ja eSports-toiminnan järjestäjänä, joiden kautta yhdistyksellä oli jo ennestään yhteys pelialan toimijoiden ammattiyhteisöön. Esittelimme pelin ideaa useammalle pelialan ammattilaiselle, jotka tuntuivat innostuvan samalla lailla kuin mekin.\n\n Tämän innoittamana PRG:n tiimi alkoi pohtia laajemmin pelien potentiaalia ajatuksia herättävänä taiteena– ja pelien roolia taidekasvatuksessa ylipäätään. Miten pelit voitaisiin tuoda kouluympäristöön mielekkäällä tavalla, teatterin, kuvataiteen, kirjallisuuden ja elokuvan rinnalle? Taidekasvatuksessa olennaista ei ole ainoastaan historiallisten suuntausten ja esimerkkien käsittely, vaan myös yhteisen teoksen kokeminen ja sen merkitysten tarkasteleminen yhdessä. Mutta miten tämä voisi toteutua pelien kohdalla?\n\n Pelialan osaajien kanssa käydyissä keskusteluissa kävi ilmi, että heidän yrityksensä saada kouluille pelitestauksia olivat pääasiassa epäonnistuneet, sillä koulut eivät tee kaupallista yhteistyötä. PRG ry näki tässä mahdollisuuden yhdistää taidekasvatuksellisen osaamisensa pelialan tarpeisiin. Ennen kuin PRG ry vaihtoi toimialansa peleihin, se nimittäin vei teatteriesityksiä kouluihin, täytten kouluissa lakisääteisen opetussuunnitelmaan kuuluvan pykälän, jossa jokaiselle oppilaalle oli vuosittain tarjottava mahdollisuus teatteritaiteen kokemiseen ja tekemiseen. Tätä tehtiin tuottamalla näytelmiä, joita käsiteltiin työpajatyyppisesti luokissa esityksen jälkeen.\n\n Kysymys oli valmis: mitä jos veisimme ALT Zone -mobiilipelin kouluille tällä samalla sapluunalla, ja toisimme luokkahuoneeseen yhtenäisen pelikokemuksen, jota oppilaat voisivat tarkastella ohjatusti taide-elämyksenä - ja halutessaan osallistua sen jatkokehittämiseen? PRG ry on kuitenkin yhdistysmuotoinen vapaaehtoistyön osaaja, jossa ihmiset ovat tehneet unelmistaan totta ilman että raha vaihtaa omistajaa.Idea tuntui liian hyvälltä sivuutettavaksi, ja pelialan ammattilaisten verkosto lupasi auttaa matkalla oikeiden asioiden pohtimisessa. Oli otettava hyppy tuntemattomaan; työ saattoi alkaa.",

--- a/frontend-next-migration/src/shared/i18n/locales/fi/about.json
+++ b/frontend-next-migration/src/shared/i18n/locales/fi/about.json
@@ -1,11 +1,11 @@
 {
     "title": "Meistä",
-    "head-title": "Mikä PRG?",
+    "head-title": "Tämän projektin parissa työskentelee paljon erilaisia osaajia",
     "head-description": "Psyche's Royale Gaming ry on voittoa tavoittelematon pelitaiteen yhdistys, joka valmistaa ALT Zone 1.0 mobiilipeliä yhteisöllisesti.",
     "head-keywords": "ALT Zone, ALT Zone mobiilipeli, yhteisöllinen pelinkehitys, osallistu pelin tekemiseen, pelitaide mobiilipeli",
     "og-title": "Psyche's Royale Gaming ry – ALT Zone -pelitaiteen tekijät ja yhteisö",
     "og-description": "PRG ry on suomalainen voittoa tavoittelematon yhdistys, joka kehittää ALT Zone -mobiilipeliä yhdessä nuorten, vapaaehtoisten ja pelialan osaajien kanssa.",
-    "project": "On työskennellyt tässä projectissa",
+    "project": "On työskennellyt tässä projektissa",
     "locality": "Eri paikkakunnalta",
     "nationality": "Eri kansalaisuutta",
     "behind": "Vuotta matkaa takana",

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
@@ -46,4 +46,5 @@ export type DropdownWrapperProps = {
     autoClose?: boolean;
     headerClassName?: string;
     childrenWrapperClassName?: string;
+    chevronClassName?: string;
 };

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
@@ -25,6 +25,7 @@ export type DropdownWrapperProps = {
     className?: string;
     contentClassName?: string;
     contentItemClassName?: string;
+    activeItemClassName?: string;
     contentAbsolute?: boolean;
     elements: Array<DropDownElement>;
     onOpen?: () => void;

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/types/index.ts
@@ -47,4 +47,5 @@ export type DropdownWrapperProps = {
     headerClassName?: string;
     childrenWrapperClassName?: string;
     chevronClassName?: string;
+    chevronWrapperClassName?: string;
 };

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
@@ -91,6 +91,7 @@
     display: block;
     width: 100%;
     cursor: pointer;
+    position: relative;
 }
 
 .disabled {

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
@@ -11,6 +11,29 @@
     }
 }
 
+.chevronWrapper {
+    position: absolute;
+    right: 0;
+    top: 50%;
+
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    width: 24px;
+    height: 24px;
+
+    flex-shrink: 0;
+
+    transform: translateY(-50%) rotate(0deg);
+    transform-origin: center;
+    transition: transform 0.3s ease;
+}
+
+.chevronWrapperOpen {
+    transform: translateY(-50%) rotate(180deg);
+}
+
 .dropdownContent {
     padding-top: 10px;
     line-height: 40px !important;

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.module.scss
@@ -92,7 +92,7 @@
 }
 
 .dynamicHeading {
-    font: var(--font-dm-bold-m);
+    font: var(--font-dm-m);
     color: var(--primary-color);
     cursor: pointer;
 }

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
@@ -32,6 +32,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
         headerClassName = '',
         childrenWrapperClassName = '',
         chevronClassName = '',
+        chevronWrapperClassName = '',
     } = props;
 
     const [isOpen, setIsOpen] = useState<boolean>(openByDefault || staticDropdown);
@@ -207,7 +208,9 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                         {dynamicTitle}
                         {showArrow && (
                             <span
-                                className={`${cls.chevronWrapper} ${isOpen ? cls.chevronWrapperOpen : ''}`}
+                                className={`${cls.chevronWrapper} ${isOpen ? cls.chevronWrapperOpen : ''} ${
+                                    chevronWrapperClassName ?? ''
+                                }`}
                             >
                                 <Image
                                     loading="eager"

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
@@ -197,7 +197,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                     transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
                                     transition: 'transform 0.4s ease-in-out',
                                     position: 'absolute',
-                                    right: '10%',
+                                    right: '0',
                                     marginTop: '7px',
                                 }}
                             >

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
@@ -272,7 +272,9 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                         </AppLink>
                                     ) : (
                                         <span
-                                            className={''}
+                                            className={classNames(contentItemClassName, {
+                                                [cls.active]: element.active,
+                                            })}
                                             style={{
                                                 cursor: 'pointer',
                                                 color: element.active

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
@@ -17,6 +17,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
         className = '',
         contentClassName = '',
         contentItemClassName = '',
+        activeItemClassName = '',
         elements,
         isDisabled,
         children,
@@ -153,6 +154,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
     };
 
     const mainElementClass = isDisabled?.status ? cls.disabled : '';
+
     return (
         <div
             ref={rootRef}
@@ -203,7 +205,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                             >
                                 <Image
                                     loading="eager"
-                                    alt={'Chevron'}
+                                    alt="Chevron"
                                     src={chevronDown}
                                     className={cls.chevronImage}
                                 />
@@ -220,6 +222,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                     </div>
                 </div>
             )}
+
             {shouldRender && (
                 <div
                     className={classNames(cls.dropdownContent, modsContent, [contentClassName])}
@@ -247,6 +250,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                             isExternal={element.link.isExternal}
                                             className={classNames(contentItemClassName, {
                                                 [cls.active]: element.active,
+                                                [activeItemClassName]: element.active,
                                             })}
                                             onClick={() => {
                                                 if (!openByDefault && !staticDropdown) {
@@ -259,7 +263,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                             {element.link.isExternal && (
                                                 <FontAwesomeIcon
                                                     className={cls.externalLinkIcon}
-                                                    size={'2xs'}
+                                                    size="2xs"
                                                     icon={faExternalLink}
                                                     style={{
                                                         display: 'inline',
@@ -274,6 +278,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                         <span
                                             className={classNames(contentItemClassName, {
                                                 [cls.active]: element.active,
+                                                [activeItemClassName]: element.active,
                                             })}
                                             style={{
                                                 cursor: 'pointer',

--- a/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
+++ b/frontend-next-migration/src/shared/ui/DropdownWrapperV2/ui/DropdownWrapper.tsx
@@ -31,6 +31,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
         autoClose = false,
         headerClassName = '',
         childrenWrapperClassName = '',
+        chevronClassName = '',
     } = props;
 
     const [isOpen, setIsOpen] = useState<boolean>(openByDefault || staticDropdown);
@@ -78,6 +79,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                 setIsOpen(false);
             }
         };
+
         document.addEventListener('az:dropdown-select' as any, handleDropdownSelect as any);
         return () => {
             document.removeEventListener('az:dropdown-select' as any, handleDropdownSelect as any);
@@ -109,6 +111,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
             clearTimeout(closeTimer);
             setCloseTimer(null);
         }
+
         setIsOpen(true);
     };
 
@@ -119,6 +122,7 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
             setIsOpen(false);
             setCloseTimer(null);
         }, 200);
+
         setCloseTimer(timer);
     };
 
@@ -159,9 +163,17 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
         <div
             ref={rootRef}
             className={classNames(cls.DropdownWrapper, mods, [className])}
+            data-dropdown-state={
+                isOpen
+                    ? animationState === 'opening'
+                        ? 'opening'
+                        : 'open'
+                    : animationState === 'closing'
+                      ? 'closing'
+                      : 'closed'
+            }
             onMouseEnter={handleMouseEnter}
             onMouseLeave={handleMouseLeave}
-            // onBlur={handleBlur}
             onKeyDown={handleKeyDown}
             tabIndex={0}
             role="button"
@@ -195,19 +207,13 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                         {dynamicTitle}
                         {showArrow && (
                             <span
-                                style={{
-                                    transform: isOpen ? 'rotate(180deg)' : 'rotate(0deg)',
-                                    transition: 'transform 0.4s ease-in-out',
-                                    position: 'absolute',
-                                    right: '0',
-                                    marginTop: '7px',
-                                }}
+                                className={`${cls.chevronWrapper} ${isOpen ? cls.chevronWrapperOpen : ''}`}
                             >
                                 <Image
                                     loading="eager"
                                     alt="Chevron"
                                     src={chevronDown}
-                                    className={cls.chevronImage}
+                                    className={`${cls.chevronImage} ${chevronClassName}`}
                                 />
                             </span>
                         )}
@@ -294,7 +300,6 @@ export const DropdownWrapper = (props: DropdownWrapperProps) => {
                                                 element.onClickCallback?.();
                                             }}
                                         >
-                                            {/*<span className={contentItemClassName}>*/}
                                             {element.elementText}
                                         </span>
                                     )}


### PR DESCRIPTION
## 📄 **Pull Request Overview**

Closes #659 

## 🔧 **Changes Made**

**Rebuilt the About / History page**
- Reworked the page structure around the project statistics, timeline and year-based content.
- Added independent year blocks with expandable/collapsible accordion functionality.
- Added a sorting dropdown for switching between newest and oldest timeline entries.
- Added the designer credit section below the timeline.
- Implemented responsive layouts for mobile, tablet and desktop.

**Internationalization and content structure**
- Connected the new UI elements and timeline controls to i18n.
- Structured designer information in the locale JSON so additional designers and their links can be added without changing the component.
- Preserved the existing localized page content and metadata.

**UI and interaction improvements**
- Added smooth open/close transitions for timeline entries.
Implemented responsive timeline styling and controls across different viewport sizes.
- Refined the statistics cards and timeline presentation to match the intended design.

---

## ✅ **Checklist Before Submission**

- **Functionality**: I have tested my code, and it works as expected. ✅
- **JSDoc**: I have added or updated JSDoc comments for all relevant code. ✅
- **Debugging**: No `console.log()` or other debugging statements are left. ✅
- **Clean Code**: Removed commented-out or unnecessary code. ✅
- **Tests**: Added new tests or updated existing ones for the changes made. ✅
- **Documentation**: Documentation has been updated (if applicable). ✅

---

## 📝 **Additional Information**

Provide any additional context or information that reviewers may need to know:

- **Screenshots**: [Include any screenshots or videos if the changes affect the UI]
 
**Desktop with closed entries:**
<img width="2560" height="1440" alt="AboutDesktopClosed" src="https://github.com/user-attachments/assets/c91070d8-399e-4a8b-a598-5d0c5960b434" />

**Open entry in desktop:**
<img width="1186" height="1247" alt="DesktopOpenEntry" src="https://github.com/user-attachments/assets/5b1cc9c7-a665-4ac5-b1c9-6e04b1f29b63" />

**Mobile fullsize closed:** (Note: the footer and header don't actually behave like this)
<img width="750" height="5006" alt="MobileThinFullsizeClosed" src="https://github.com/user-attachments/assets/a68617a6-cb1b-4a82-b547-4677a0136e3d" />

**Mobile fullsize with open entries:**
<img width="750" height="12722" alt="MobileThinFullsizeOpen" src="https://github.com/user-attachments/assets/8b424873-0651-4cad-bde8-8f911e3e7de7" />

**Actual look of mobile upper and lower areas:**
-Upper:
<img width="372" height="662" alt="MobileThinUpper" src="https://github.com/user-attachments/assets/4c60b1b5-599c-42e2-a02d-fde967437996" />

-Lower:
<img width="368" height="542" alt="MobileThinLower" src="https://github.com/user-attachments/assets/a43a498d-0e10-47eb-bd9c-3b99f4f54087" />

**Ipad:**
-Upper:
<img width="761" height="1020" alt="IpadUpper" src="https://github.com/user-attachments/assets/ecfb907c-769e-45e3-a8ee-4f12a992a682" />

-Lower:
<img width="754" height="1015" alt="IpadLower" src="https://github.com/user-attachments/assets/6983d9b2-026e-4a84-9d2d-9beb0b8d9ec5" />

**Translations:**
<img width="1720" height="1412" alt="AboutENG" src="https://github.com/user-attachments/assets/f65754bd-aedf-4d0c-85cf-ff2cabfaaaa6" />



- **Dependencies**: No new dependencies were added.
- **Known Issues**: No known functional issues.
